### PR TITLE
fix: Revert "build(deps): bump pydantic from 1.10.2 to 1.10.13 in /api_test"

### DIFF
--- a/api_test/requirements.txt
+++ b/api_test/requirements.txt
@@ -12,7 +12,7 @@ setuptools == 69.2.0
 urllib3 >= 1.25.3
 aenum == 3.1.11
 retrying == 1.3.4
-pydantic == 1.10.13
+pydantic == 1.10.2
 tenacity==8.2.2
 jsonschema==4.21.1
 requests~=2.31.0


### PR DESCRIPTION
Reverts aws-samples/Intelli-Agent#276