### PR TITLE
feat: add details in monitor

### DIFF
--- a/source/lambda/online/common_logic/common_utils/monitor_utils.py
+++ b/source/lambda/online/common_logic/common_utils/monitor_utils.py
@@ -1,0 +1,111 @@
+import logging
+
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def _generate_markdown_link(file_path: str) -> str:
+    file_name = file_path.split("/")[-1]
+    markdown_link = f"[{file_name}]({file_path})"
+    return markdown_link
+
+
+def format_qq_data(data) -> str:
+    """
+    Formats QQ match result.
+
+    Args:
+        data (list): A list of dictionaries containing 'source', 'score', and 'page_content' keys.
+
+    Returns:
+        str: A markdown table string representing the formatted data.
+    """
+    if data is None or len(data) == 0:
+        return ""
+    
+    markdown_table = "**QQ Match Result**\n"
+    markdown_table += "| Source | Score | Question | Answer |\n"
+    markdown_table += "|-----|-----|-----|-----|\n"
+
+    for qq_item in data:
+        qq_source = _generate_markdown_link(qq_item.get("source", ""))
+        qq_score = qq_item.get("score", -1)
+        qq_question = qq_item.get("page_content", "").replace("\n", "<br>")
+        qq_answer = qq_item.get("answer", "").replace("\n", "<br>")
+        markdown_table += f"| {qq_source} | {qq_score} | {qq_question} | {qq_answer} |\n"
+
+    return markdown_table
+
+
+def format_rag_data(data, qq_result) -> str:
+    """
+    Formats the given data into a markdown table.
+
+    Args:
+        data (list): A list of dictionaries containing 'source', 'score', and 'page_content' keys.
+        qq_result (list): QQ match result
+
+    Returns:
+        str: A markdown table string representing the formatted data.
+    """
+    if data is None or len(data) == 0:
+        return ""
+
+    markdown_table = "| Source | Score | RAG Context |\n"
+    markdown_table += "|-----|-----|-----|\n"
+    for item in data:
+        source = _generate_markdown_link(item.get("source", ""))
+        score = item.get("score", -1)
+        page_content = item.get("page_content", "").replace("\n", "<br>")
+        markdown_table += f"| {source} | {score} | {page_content} |\n\n"
+    
+    markdown_table += "**QQ Match Result**\n"
+    markdown_table += "| Source | Score | Question | Answer |\n"
+    markdown_table += "|-----|-----|-----|-----|\n"
+
+    for qq_item in qq_result:
+        qq_source = _generate_markdown_link(qq_item.get("source", ""))
+        qq_score = qq_item.get("score", -1)
+        qq_question = qq_item.get("page_content", "").replace("\n", "<br>")
+        qq_answer = qq_item.get("answer", "").replace("\n", "<br>")
+        markdown_table += f"| {qq_source} | {qq_score} | {qq_question} | {qq_answer} |\n"
+
+    return markdown_table
+
+
+def is_null_or_empty(value):
+    if value is None:
+        return True
+    elif isinstance(value, (dict, list, str)) and not value:
+        return True
+    return False
+
+
+def format_preprocess_output(ori_query, rewrite_query):
+    if is_null_or_empty(ori_query) or is_null_or_empty(rewrite_query):
+        return ""
+
+    markdown_table = "| Original Query | Rewritten Query |\n"
+    markdown_table += "|-------|-------|\n"
+    markdown_table += f"| {ori_query} | {rewrite_query} |\n"
+
+    return markdown_table
+
+
+def format_intention_output(data):
+    if is_null_or_empty(data):
+        return ""
+
+    markdown_table = "| Query | Score | Name | Intent | Additional Info |\n"
+    markdown_table += "|-------|-------|-------|-------|-------|\n"
+    for item in data:
+        query = item.get("query", "")
+        score = item.get("score", "")
+        name = item.get("name", "")
+        intent = item.get("intent", "")
+        kwargs = ', '.join(
+            [f'{k}: {v}' for k, v in item.get('kwargs', {}).items()])
+        markdown_table += f"| {query} | {score} | {name} | {intent} | {kwargs} |\n"
+
+    return markdown_table

--- a/source/lambda/online/functions/lambda_common_tools/rag.py
+++ b/source/lambda/online/functions/lambda_common_tools/rag.py
@@ -4,44 +4,15 @@ from common_logic.common_utils.constant import (
     LLMTaskType
 )
 from common_logic.common_utils.lambda_invoke_utils import send_trace
-
-
-def _generate_markdown_link(file_path: str) -> str:
-    file_name = file_path.split("/")[-1]
-    markdown_link = f"[{file_name}]({file_path})"
-    return markdown_link
-
-
-def format_rag_data(data) -> str:
-    """
-    Formats the given data into a markdown table.
-
-    Args:
-        data (list): A list of dictionaries containing 'source', 'score', and 'page_content' keys.
-
-    Returns:
-        str: A markdown table string representing the formatted data.
-    """
-    if data is None or len(data) == 0:
-        return ""
-
-    markdown_table = "| Source | Score | RAG Context |\n"
-    markdown_table += "|-----|-----|-----|\n"
-    for item in data:
-        source = _generate_markdown_link(item.get("source", ""))
-        score = item.get("score", -1)
-        page_content = item.get("page_content", "").replace("\n", "<br>")
-        markdown_table += f"| {source} | {score} | {page_content} |\n"
-
-    return markdown_table
+from common_logic.common_utils.monitor_utils import format_rag_data
 
 
 def lambda_handler(event_body, context=None):
-    state = event_body['state']
+    state = event_body["state"]
     print(event_body)
     context_list = []
     # Add qq match results
-    context_list.extend(state['qq_match_results'])
+    context_list.extend(state["qq_match_results"])
     figure_list = []
     retriever_params = state["chatbot_config"]["private_knowledge_config"]
     retriever_params["query"] = state[retriever_params.get(
@@ -64,7 +35,7 @@ def lambda_handler(event_body, context=None):
     unique_figure_list = [dict(t) for t in unique_set]
     state['extra_response']['figures'] = unique_figure_list
 
-    context_md = format_rag_data(output["result"]["docs"])
+    context_md = format_rag_data(output["result"]["docs"], state["qq_match_contexts"])
     send_trace(
         f"\n\n{context_md}\n\n", enable_trace=state["enable_trace"])
 

--- a/source/portal/src/pages/chatbot/components/Message.css
+++ b/source/portal/src/pages/chatbot/components/Message.css
@@ -14,9 +14,11 @@
     background-color: #f2f2f2;
     padding: 8px;
     border: 1px solid #ddd;
+    min-width: 120px;
 }
 
 .custom-table-cell {
     padding: 8px;
     border: 1px solid #ddd;
+    min-width: 120px;
 }


### PR DESCRIPTION
Fixes #


<details>
<summary>🤖 AI-Generated PR Description (Powered by Amazon Bedrock)</summary>

# Description
This pull request introduces a new utility function `monitor_utils.py` for monitoring and logging purposes in the online lambda functions. Additionally, it includes modifications to the `rag.py` file, which likely involves changes related to the Retrieval-Augmented Generation (RAG) model. The `common_entry.py` file has also been updated, potentially affecting the common entry point for online lambda functions. Finally, styling changes have been made to the `Message.css` file, which is part of the chatbot user interface in the portal application.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## File Stats Summary

File number involved in this PR: *4*, unfold to see the details:

<details>

The file changes summary is as follows:

| <div style="width:150px">Files</div> | <div style="width:160px">Changes</div> | <div style="width:320px">Change Summary</div> |
|:-------|:--------|:--------------|
| source/portal/src/pages/chatbot/components/Message.css | 2 added, 0 removed | The code changes add a minimum width of 120px for table headers and cells, ensuring a consistent layout across different screen sizes. |
| source/lambda/online/common_logic/common_utils/monitor_utils.py | 111 added, 0 removed | This code defines several functions to format data into markdown tables, including generating markdown links, formatting question-answering results, retrieval-augmented generation (RAG) results, preprocessing outputs, and intention outputs. |
| source/lambda/online/lambda_main/main_utils/online_entries/common_entry.py | 5 added, 42 removed | The code changes include:

1. Removed the import for the `json` module.
2. Added imports for `format_intention_output`, `format_preprocess_output`, and `format_qq_data` functions from `common_logic.common_utils.monitor_utils`.
3. Added a new key `qq_match_contexts` to the `ChatbotState` TypedDict to store the retrieved contexts.
4. Removed the `is_null_or_empty`, `format_preprocess_output`, and `format_intention_output` functions.
5. In the `intention_detection` function, formatted the retrieved document using `format_qq_data` before sending the trace.
6. Updated the state with the `qq_match_contexts` key containing the retrieved documents. |
| source/lambda/online/functions/lambda_common_tools/rag.py | 8 added, 18 removed | The code changes include printing the event body, adding RAG debug print statements, modifying the format_rag_data function call with additional arguments, and removing commented code. |

</details>
  

</details>
