### PR TITLE
refactor: ignore document case when test third kb

### DIFF
--- a/api_test/buildspec-third.yaml
+++ b/api_test/buildspec-third.yaml
@@ -181,7 +181,7 @@ phases:
         cat .env
         source agentVenv/bin/activate
         # pytest test_case --continue-on-collection-errors --log-cli-level=INFO
-        pytest test_case --continue-on-collection-errors --log-cli-level=INFO --json-report --json-report-file=detail_third.json --html=report_third.html --self-contained-html > detail_third.log
+        pytest test_case --ignore=test_case/test_01_rest_document.py --continue-on-collection-errors --log-cli-level=INFO --json-report --json-report-file=detail_third.json --html=report_third.html --self-contained-html > detail_third.log
         popd
         test_complete_time=$(date +"%Y-%m-%d_%H-%M-%S")
         echo "----------------------------------------------------------------"

--- a/api_test/test_case/test_01_rest_document.py
+++ b/api_test/test_case/test_01_rest_document.py
@@ -17,7 +17,7 @@ caller_identity = boto3.client('sts').get_caller_identity()
 partition = caller_identity['Arn'].split(':')[1]
 
 class TestDocument:
-    """DataSourceDiscovery test stubs"""
+    """Document test stubs"""
     upload_success_msg = 'The S3 presigned url is generated'
     upload_prefix_data = 'https://intelli-agent-apiconstructllmbotdocument'
 

--- a/api_test/test_case/test_02_ws_chat.py
+++ b/api_test/test_case/test_02_ws_chat.py
@@ -11,7 +11,7 @@ from .utils import step
 logger = logging.getLogger(__name__)
 
 class TestChat:
-    """DataSourceDiscovery test stubs"""
+    """Chat test stubs"""
 
     @classmethod
     def setup_class(cls):

--- a/api_test/test_case/test_04_rest_prompt.py
+++ b/api_test/test_case/test_04_rest_prompt.py
@@ -20,7 +20,7 @@ caller_identity = boto3.client('sts').get_caller_identity()
 partition = caller_identity['Arn'].split(':')[1]
 
 class TestPrompt:
-    """DataSourceDiscovery test stubs"""
+    """Prompt test stubs"""
 
     @classmethod
     def setup_class(cls):

--- a/api_test/test_case/test_05_rest_intention.py
+++ b/api_test/test_case/test_05_rest_intention.py
@@ -19,8 +19,8 @@ s3_client = boto3.client('s3')
 caller_identity = boto3.client('sts').get_caller_identity()
 partition = caller_identity['Arn'].split(':')[1]
 
-class TestSession:
-    """Session test stubs"""
+class TestIntention:
+    """Intention test stubs"""
 
     @classmethod
     def setup_class(cls):
@@ -41,7 +41,7 @@ class TestSession:
         step(
             f"[{datetime.datetime.strftime(datetime.datetime.now(),'%Y-%m-%d')}] [{__name__}] Test end."
         )
-    
-    def test_38_list_session(self):
+
+    def test_39_list_prompt(self):
         # TBD
         pass


### PR DESCRIPTION
Fixes #


<details>
<summary>🤖 AI-Generated PR Description (Powered by Amazon Bedrock)</summary>

# Description
This pull request includes updates to the API testing suite for the project. The changes involve modifications to existing test cases and the addition of a new test case for testing the REST intention functionality.

The following files have been modified:

- `api_test/buildspec-third.yaml`: Updated build specification file.
- `api_test/gen-report-lambda.py`: Updated the report generation script for test results.
- `api_test/test_case/test_01_rest_document.py`: Modified the test case for testing the REST document functionality.
- `api_test/test_case/test_02_ws_chat.py`: Modified the test case for testing the WebSocket chat functionality.
- `api_test/test_case/test_03_rest_session.py`: Modified the test case for testing the REST session functionality.
- `api_test/test_case/test_04_rest_prompt.py`: Modified the test case for testing the REST prompt functionality.

Additionally, a new test case has been added:

- `api_test/test_case/test_05_rest_intention.py`: Added a new test case for testing the REST intention functionality.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## File Stats Summary

File number involved in this PR: *7*, unfold to see the details:

<details>

The file changes summary is as follows:

| <div style="width:150px">Files</div> | <div style="width:160px">Changes</div> | <div style="width:320px">Change Summary</div> |
|:-------|:--------|:--------------|
| api_test/test_case/test_04_rest_prompt.py | 1 added, 1 removed | The code change updates the class docstring from "DataSourceDiscovery test stubs" to "Prompt test stubs". |
| api_test/test_case/test_03_rest_session.py | 1 added, 1 removed | The code change updates the docstring comment for the TestSession class from "DataSourceDiscovery test stubs" to "Session test stubs". |
| api_test/buildspec-third.yaml | 1 added, 1 removed | The code change adds an `--ignore` flag to the `pytest` command, excluding the `test_case/test_01_rest_document.py` file from the test suite execution. |
| api_test/test_case/test_02_ws_chat.py | 1 added, 1 removed | The code change updates the docstring comment for the TestChat class from "DataSourceDiscovery test stubs" to "Chat test stubs". |
| api_test/test_case/test_05_rest_intention.py | 47 added, 0 removed | This code change sets up a test class for testing an API using the OpenAPI client library, including importing necessary modules, loading environment variables, configuring the API client, and defining setup and teardown methods for the test class. |
| api_test/gen-report-lambda.py | 5 added, 5 removed | The code changes remove the square brackets around "BuiltIn KB" and "Third KB" text, calculate the test coverage percentage by rounding the ratio to 2 decimal places and multiplying by 100, and format the summary report with better readability by separating Built-In KB and Third KB details. |
| api_test/test_case/test_01_rest_document.py | 1 added, 1 removed | The code change updates the docstring comment for the TestDocument class from "DataSourceDiscovery test stubs" to "Document test stubs". |

</details>
  

</details>
