### PR TITLE
feat: support passing AKSK to the bedrock client

### DIFF
--- a/source/infrastructure/bin/config.ts
+++ b/source/infrastructure/bin/config.ts
@@ -36,6 +36,8 @@ export function getConfig(): SystemConfig {
     chat: {
       enabled: true,
       bedrockRegion: "us-east-1",
+      bedrockAk: "",
+      bedrockSk: "",
       amazonConnect: {
         enabled: true
       }

--- a/source/infrastructure/lib/chat/chat-stack.ts
+++ b/source/infrastructure/lib/chat/chat-stack.ts
@@ -134,6 +134,8 @@ export class ChatStack extends NestedStack implements ChatStackOutputs {
         KNOWLEDGE_BASE_ENABLED: props.config.knowledgeBase.enabled.toString(),
         KNOWLEDGE_BASE_TYPE: JSON.stringify(props.config.knowledgeBase.knowledgeBaseType || {}),
         BEDROCK_REGION: props.config.chat.bedrockRegion,
+        BEDROCK_AWS_ACCESS_KEY_ID: props.config.chat.bedrockAk || "",
+        BEDROCK_AWS_SECRET_ACCESS_KEY: props.config.chat.bedrockSk || ""
       },
       layers: [apiLambdaOnlineSourceLayer, apiLambdaJobSourceLayer],
     });

--- a/source/infrastructure/lib/shared/types.ts
+++ b/source/infrastructure/lib/shared/types.ts
@@ -28,6 +28,8 @@ export interface SystemConfig {
   chat: {
     enabled: boolean;
     bedrockRegion: string;
+    bedrockAk?: string;
+    bedrockSk?: string;
     amazonConnect: {
       enabled: boolean;
     }

--- a/source/lambda/online/common_logic/langchain_integration/chat_models/bedrock_models.py
+++ b/source/lambda/online/common_logic/langchain_integration/chat_models/bedrock_models.py
@@ -1,4 +1,5 @@
 import os
+import boto3
 from langchain_aws.chat_models import ChatBedrockConverse as _ChatBedrockConverse
 from common_logic.common_utils.constant import (
     MessageType,
@@ -37,14 +38,32 @@ class Claude2(Model):
             or os.environ.get("BEDROCK_REGION", None)
             or None
         )
-        llm = ChatBedrockConverse(
-            credentials_profile_name=credentials_profile_name,
-            region_name=region_name,
-            model=cls.model_id,
-            enable_auto_tool_choice=cls.enable_auto_tool_choice,
-            enable_prefill=cls.enable_prefill,
-            **model_kwargs,
-        )
+        br_aws_access_key_id = os.environ.get("BEDROCK_AWS_ACCESS_KEY_ID", "")
+        br_aws_secret_access_key = os.environ.get("BEDROCK_AWS_SECRET_ACCESS_KEY", "")
+
+        if br_aws_access_key_id != "" and br_aws_secret_access_key != "":
+            logger.info(f"Bedrock Using AWS AKSK from environment variables. Key ID: {br_aws_access_key_id}")
+
+            client = boto3.client("bedrock-runtime", region_name=region_name, 
+                                  aws_access_key_id=br_aws_access_key_id, aws_secret_access_key=br_aws_secret_access_key)
+
+            llm = ChatBedrockConverse(
+                client=client,
+                region_name=region_name,
+                model=cls.model_id,
+                enable_auto_tool_choice=cls.enable_auto_tool_choice,
+                enable_prefill=cls.enable_prefill,
+                **model_kwargs,
+            )
+        else:
+            llm = ChatBedrockConverse(
+                credentials_profile_name=credentials_profile_name,
+                region_name=region_name,
+                model=cls.model_id,
+                enable_auto_tool_choice=cls.enable_auto_tool_choice,
+                enable_prefill=cls.enable_prefill,
+                **model_kwargs,
+            )
         llm.client.converse_stream = llm_messages_print_decorator(
             llm.client.converse_stream)
         llm.client.converse = llm_messages_print_decorator(llm.client.converse)


### PR DESCRIPTION
support passing AKSK to the bedrock client for invoking LLM from another account.


<details>
<summary>🤖 AI-Generated PR Description (Powered by Amazon Bedrock)</summary>

# Description
This pull request includes modifications to the configuration file for the infrastructure bin, the chat stack definition, shared types, and the Langchain integration for the online chat models. The changes aim to improve the overall functionality and performance of the chat system.

## Type of change
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## File Stats Summary

File number involved in this PR: *4*, unfold to see the details:

<details>

The file changes summary is as follows:

| <div style="width:150px">Files</div> | <div style="width:160px">Changes</div> | <div style="width:320px">Change Summary</div> |
|:-------|:--------|:--------------|
| source/infrastructure/lib/shared/types.ts | 2 added, 0 removed | The code adds optional properties `bedrockAk` and `bedrockSk` to the `chat` object in the `SystemConfig` interface. |
| source/infrastructure/bin/config.ts | 2 added, 0 removed | The code adds two new configuration properties, 'bedrockAk' and 'bedrockSk', to the chat object in the SystemConfig, likely for authentication purposes. |
| source/infrastructure/lib/chat/chat-stack.ts | 2 added, 0 removed | This code change adds environment variables for AWS access key and secret access key for Bedrock integration to the ChatStack Lambda function. |
| source/lambda/online/common_logic/langchain_integration/chat_models/bedrock_models.py | 27 added, 8 removed | The code changes add the ability to use AWS access key and secret access key from environment variables to initialize the ChatBedrockConverse model, in addition to the existing method of using a credentials profile name. |

</details>
  

</details>
