### PR TITLE
feat: support Nova Pro

### DIFF
--- a/.viperlightignore
+++ b/.viperlightignore
@@ -15,6 +15,7 @@ source/portal/src/utils/const.ts
 source/lambda/online/lambda_main/test/main_local_test_retail.py
 source/lambda/online/lambda_main/test/main_local_test_common.py
 source/lambda/online/functions/retail_tools/lambda_product_information_search/product_information_search.py
+source/lambda/online/common_logic/common_utils/prompt_utils.py
 source/lambda/job/test/prepare_data.py
 README.md
 README_zh-cn.md

--- a/source/lambda/online/common_logic/common_utils/constant.py
+++ b/source/lambda/online/common_logic/common_utils/constant.py
@@ -146,7 +146,8 @@ class LLMModelType(ConstantBase):
     LLAMA3_2_90B_INSTRUCT = "us.meta.llama3-2-90b-instruct-v1:0"
     MISTRAL_LARGE_2407 = "mistral.mistral-large-2407-v1:0"
     COHERE_COMMAND_R_PLUS = "cohere.command-r-plus-v1:0"
-    NOVA_PRO = "amazon.nova-pro-v1:0"
+    # NOVA_PRO = "amazon.nova-pro-v1:0"
+    NOVA_PRO = "us.amazon.nova-pro-v1:0"
 
 
 class EmbeddingModelType(ConstantBase):

--- a/source/lambda/online/common_logic/common_utils/constant.py
+++ b/source/lambda/online/common_logic/common_utils/constant.py
@@ -146,6 +146,7 @@ class LLMModelType(ConstantBase):
     LLAMA3_2_90B_INSTRUCT = "us.meta.llama3-2-90b-instruct-v1:0"
     MISTRAL_LARGE_2407 = "mistral.mistral-large-2407-v1:0"
     COHERE_COMMAND_R_PLUS = "cohere.command-r-plus-v1:0"
+    NOVA_PRO = "amazon.nova-pro-v1:0"
 
 
 class EmbeddingModelType(ConstantBase):

--- a/source/lambda/online/common_logic/common_utils/prompt_utils.py
+++ b/source/lambda/online/common_logic/common_utils/prompt_utils.py
@@ -126,18 +126,56 @@ get_prompt_templates_from_ddb = prompt_template_manager.get_prompt_templates_fro
 
 #### rag template #######
 
-CLAUDE_RAG_SYSTEM_PROMPT = """You are a customer service agent, and answering user's query. You ALWAYS follow these response rules when writing your response:
+CLAUDE_RAG_SYSTEM_PROMPT = """
+You are a customer service agent responding to user queries. ALWAYS adhere to these response rules:
+
 <response_rules>
-- 如果<docs> </docs>里面的内容包含markdown格式的图片，如 ![image](https://www.demo.com/demo.png)，请保留这个markdown格式的图片，并将他原封不动的输出到回答内容的最后，注意：不要修改这个markdown格式的图片.
-- NERVER say "根据搜索结果/大家好/谢谢/根据这个文档...".
-- 回答简单明了
-- 如果问题与<docs> </docs>里面的内容不相关，直接回答 "根据内部知识库，找不到相关内容。"
+1. Image Handling:
+   - If <docs></docs> contains markdown-formatted images, append them unaltered to the end of your response.
+   - Only process markdown-formatted images within <docs></docs>.
+   - IMPORTANT: If no markdown-formatted images are present in <docs></docs>, do not add any image references to your response.
+
+2. Language and Tone:
+   - Never use phrases like "According to search results," "Hello everyone," "Thank you," or "According to this document..."
+   - Provide concise and clear answers.
+   - Maintain a professional and helpful tone throughout the response.
+
+3. Relevance:
+   - If the query is unrelated to the content in <docs></docs>, respond with: "根据内部知识库，找不到相关内容。"
+
+4. Reference Citation:
+   - Include the context ID you refer to in your response using the <reference> tag.
+   - The context ID should be the index of the document in the <docs> tag.
+   - Always use the correct format: \n<reference>X</reference>, where X is the document index.
+   - Example: \n<reference>1</reference> for <doc index="1"></doc>
+   - All <reference> tags should be in the beginning of the response
+   - IMPORTANT: Ensure that the opening tag <reference> always comes before the number, and the closing tag </reference> always comes after the number.
+
+5. Language Adaptation:
+   - Respond in the same language as the user's query.
+   - If the query is in a language other than English, adapt your response accordingly.
+
+6. Confidentiality:
+   - Do not disclose any information not present in the provided documents.
+   - If asked about topics outside your knowledge base, politely state that you don't have that information.
+
+7. Formatting:
+   - Use appropriate formatting (bold, italics, bullet points) to enhance readability when necessary.
+
+8. Completeness:
+   - Ensure your response addresses all aspects of the user's query.
+   - If multiple relevant documents are provided, synthesize the information coherently.
+
+9. Tag Verification:
+   - Before finalizing your response, double-check all <reference> tags to ensure they are correctly formatted.
+   - If you find any incorrectly formatted tags (e.g., 1</reference>), correct them to the proper format (\n<reference>1</reference>).
 </response_rules>
 
-Here are some documents for you to reference for your query.
+Reference the following documents to answer the query:
 <docs>
 {context}
-</docs>"""
+</docs>
+"""
 
 register_prompt_templates(
     model_ids=[

--- a/source/lambda/online/common_logic/common_utils/prompt_utils.py
+++ b/source/lambda/online/common_logic/common_utils/prompt_utils.py
@@ -21,7 +21,8 @@ EXPORT_MODEL_IDS = [
     LLMModelType.CLAUDE_3_5_SONNET_V2,
     LLMModelType.LLAMA3_1_70B_INSTRUCT,
     LLMModelType.MISTRAL_LARGE_2407,
-    LLMModelType.COHERE_COMMAND_R_PLUS
+    LLMModelType.COHERE_COMMAND_R_PLUS,
+    LLMModelType.NOVA_PRO,
 ]
 
 EXPORT_SCENES = [
@@ -192,6 +193,7 @@ register_prompt_templates(
         LLMModelType.LLAMA3_2_90B_INSTRUCT,
         LLMModelType.MISTRAL_LARGE_2407,
         LLMModelType.COHERE_COMMAND_R_PLUS,
+        LLMModelType.NOVA_PRO,
     ],
     task_type=LLMTaskType.RAG,
     prompt_template=CLAUDE_RAG_SYSTEM_PROMPT,
@@ -312,7 +314,7 @@ register_prompt_templates(
         LLMModelType.LLAMA3_2_90B_INSTRUCT,
         LLMModelType.MISTRAL_LARGE_2407,
         LLMModelType.COHERE_COMMAND_R_PLUS,
-
+        LLMModelType.NOVA_PRO,
     ],
     task_type=LLMTaskType.CONVERSATION_SUMMARY_TYPE,
     prompt_template=CQR_SYSTEM_PROMPT,
@@ -337,6 +339,7 @@ register_prompt_templates(
         LLMModelType.LLAMA3_2_90B_INSTRUCT,
         LLMModelType.MISTRAL_LARGE_2407,
         LLMModelType.COHERE_COMMAND_R_PLUS,
+        LLMModelType.NOVA_PRO,
     ],
     task_type=LLMTaskType.CONVERSATION_SUMMARY_TYPE,
     prompt_template=CQR_USER_PROMPT_TEMPLATE,
@@ -362,6 +365,7 @@ register_prompt_templates(
         LLMModelType.LLAMA3_2_90B_INSTRUCT,
         LLMModelType.MISTRAL_LARGE_2407,
         LLMModelType.COHERE_COMMAND_R_PLUS,
+        LLMModelType.NOVA_PRO,
     ],
     task_type=LLMTaskType.CONVERSATION_SUMMARY_TYPE,
     prompt_template=json.dumps(CQR_FEW_SHOTS, ensure_ascii=False, indent=2),
@@ -420,7 +424,7 @@ register_prompt_templates(
 AGENT_SYSTEM_PROMPT = """\
 You are a helpful and honest AI assistant. Today is {date},{weekday}. 
 Here are some guidelines for you:
-<guidlines>
+<guidelines>
 - Here are steps for you to decide to use which tool:
     1. Determine whether the current context is sufficient to answer the user's question.
     2. If the current context is sufficient to answer the user's question, call the `give_final_response` tool.
@@ -428,7 +432,7 @@ Here are some guidelines for you:
     4. If any of required parameters of the tool you want to call do not appears in context, call the `give_rhetorical_question` tool to ask the user for more information. 
 - Always output with the same language as the content from user. If the content is English, use English to output. If the content is Chinese, use Chinese to output.
 - Always call one tool at a time.
-</guidlines>
+</guidelines>
 Here's some context for reference:
 <context>
 {context}
@@ -479,6 +483,7 @@ register_prompt_templates(
         LLMModelType.CLAUDE_3_5_SONNET,
         LLMModelType.CLAUDE_3_5_SONNET_V2,
         LLMModelType.CLAUDE_3_5_HAIKU,
+        LLMModelType.NOVA_PRO,
         # LLMModelType.LLAMA3_1_70B_INSTRUCT,
         # LLMModelType.LLAMA3_2_90B_INSTRUCT,
         # LLMModelType.MISTRAL_LARGE_2407,
@@ -496,7 +501,7 @@ You are a helpful and honest AI assistant. Today is {date},{weekday}.
 Here's some context for reference:
 {context}
 
-## Guidlines
+## Guidelines
 Here are some guidelines for you:
 - Here are strategies for you to decide to use which tool:
     1. Determine whether the current context is sufficient to answer the user's question.
@@ -536,6 +541,7 @@ register_prompt_templates(
         LLMModelType.LLAMA3_2_90B_INSTRUCT,
         LLMModelType.MISTRAL_LARGE_2407,
         LLMModelType.COHERE_COMMAND_R_PLUS,
+        LLMModelType.NOVA_PRO,
     ],
     task_type=LLMTaskType.TOOL_CALLING_API,
     prompt_template=TOOL_FEWSHOT_PROMPT,

--- a/source/lambda/online/common_logic/common_utils/response_utils.py
+++ b/source/lambda/online/common_logic/common_utils/response_utils.py
@@ -72,7 +72,6 @@ def stream_response(event_body: dict, response: dict):
     ws_connection_id = event_body["ws_connection_id"]
     custom_message_id = event_body["custom_message_id"]
     answer = response["answer"]
-    figure = response.get("ddb_additional_kwargs", {}).get("figure")
     if isinstance(answer, str):
         answer = iter([answer])
 
@@ -133,10 +132,13 @@ def stream_response(event_body: dict, response: dict):
                 "message_type": StreamMessageType.CONTEXT,
                 "message_id": f"ai_{message_id}",
                 "custom_message_id": custom_message_id,
+                "ddb_additional_kwargs": {},
                 **response["extra_response"]
             }
-            if figure and len(figure) > 1:
-                context_msg["figure"] = figure
+
+            figure = response.get("extra_response").get("ref_figures", [])
+            if figure and figure[0]:
+                context_msg["ddb_additional_kwargs"]["figure"] = figure[0][:2]
             send_to_ws_client(
                 message=context_msg,
                 ws_connection_id=ws_connection_id

--- a/source/lambda/online/common_logic/langchain_integration/chains/__init__.py
+++ b/source/lambda/online/common_logic/langchain_integration/chains/__init__.py
@@ -39,6 +39,7 @@ def _import_chat_chain():
     Baichuan2Chat13B4BitsChatChain,
     Claude3HaikuChatChain,
     Claude3SonnetChatChain,
+    NovaProChatChain
 )
 
 def _import_conversation_summary_chain():
@@ -48,7 +49,8 @@ def _import_conversation_summary_chain():
     Claude21ConversationSummaryChain,
     Claude3HaikuConversationSummaryChain,
     Claude3SonnetConversationSummaryChain,
-    Internlm2Chat20BConversationSummaryChain
+    Internlm2Chat20BConversationSummaryChain,
+    NovaProConversationSummaryChain
 )
 
 def _import_intention_chain():
@@ -71,7 +73,8 @@ def _import_rag_chain():
     ClaudeInstanceRAGLLMChain,
     Claude3HaikuRAGLLMChain,
     Claude3SonnetRAGLLMChain,
-    Baichuan2Chat13B4BitsKnowledgeQaChain
+    Baichuan2Chat13B4BitsKnowledgeQaChain,
+    NovaProRAGLLMChain
 )
 
 
@@ -117,7 +120,8 @@ def _import_hyde_chain():
     Claude3SonnetHydeChain,
     ClaudeInstanceHydeChain,
     Internlm2Chat20BHydeChain,
-    Internlm2Chat7BHydeChain
+    Internlm2Chat7BHydeChain,
+    NovaProHydeChain
 )
 
 def _import_query_rewrite_chain():
@@ -128,7 +132,8 @@ def _import_query_rewrite_chain():
     Claude3HaikuQueryRewriteChain,
     Claude3SonnetQueryRewriteChain,
     Internlm2Chat20BQueryRewriteChain,
-    Internlm2Chat7BQueryRewriteChain
+    Internlm2Chat7BQueryRewriteChain,
+    NovaProQueryRewriteChain
 )
 
 
@@ -138,7 +143,8 @@ def _import_tool_calling_chain_claude_xml():
     Claude3HaikuToolCallingChain,
     Claude2ToolCallingChain,
     Claude3SonnetToolCallingChain,
-    ClaudeInstanceToolCallingChain
+    ClaudeInstanceToolCallingChain,
+    NovaProToolCallingChain
 )
 
 def _import_retail_conversation_summary_chain():
@@ -169,7 +175,8 @@ def _import_tool_calling_chain_api():
         Claude3SonnetToolCallingChain,
         Llama31Instruct70BToolCallingChain,
         CohereCommandRPlusToolCallingChain,
-        MistraLlarge2407ToolCallingChain
+        MistraLlarge2407ToolCallingChain,
+        NovaProToolCallingChain,
     )
 
 

--- a/source/lambda/online/common_logic/langchain_integration/chains/chat_chain.py
+++ b/source/lambda/online/common_logic/langchain_integration/chains/chat_chain.py
@@ -372,3 +372,7 @@ class ChatGPT4ChatChain(ChatGPT35ChatChain):
 
 class ChatGPT4oChatChain(ChatGPT35ChatChain):
     model_id = LLMModelType.CHATGPT_4O
+
+
+class NovaProChatChain(Claude2ChatChain):
+    model_id = LLMModelType.NOVA_PRO

--- a/source/lambda/online/common_logic/langchain_integration/chains/conversation_summary_chain.py
+++ b/source/lambda/online/common_logic/langchain_integration/chains/conversation_summary_chain.py
@@ -254,3 +254,7 @@ class Qwen2Instruct7BConversationSummaryChain(Claude2ConversationSummaryChain):
 
 class GLM4Chat9BConversationSummaryChain(Claude2ConversationSummaryChain):
     model_id = LLMModelType.GLM_4_9B_CHAT
+
+
+class NovaProConversationSummaryChain(Claude2ConversationSummaryChain):
+    model_id = LLMModelType.NOVA_PRO

--- a/source/lambda/online/common_logic/langchain_integration/chains/hyde_chain.py
+++ b/source/lambda/online/common_logic/langchain_integration/chains/hyde_chain.py
@@ -101,3 +101,7 @@ class Internlm2Chat7BHydeChain(Internlm2Chat7BChatChain):
 class Internlm2Chat20BHydeChain(Internlm2Chat7BHydeChain):
     model_id = LLMModelType.INTERNLM2_CHAT_20B
     intent_type = HYDE_TYPE
+
+
+class NovaProHydeChain(Claude2HydeChain):
+    model_id = LLMModelType.NOVA_PRO

--- a/source/lambda/online/common_logic/langchain_integration/chains/query_rewrite_chain.py
+++ b/source/lambda/online/common_logic/langchain_integration/chains/query_rewrite_chain.py
@@ -87,7 +87,7 @@ class Claude3SonnetQueryRewriteChain(Claude2QueryRewriteChain):
 
 
 class Claude35SonnetQueryRewriteChain(Claude2QueryRewriteChain):
-    mdoel_id = LLMModelType.CLAUDE_3_5_SONNET
+    model_id = LLMModelType.CLAUDE_3_5_SONNET
 
 
 class Claude35SonnetV2QueryRewriteChain(Claude2QueryRewriteChain):
@@ -151,3 +151,8 @@ class Internlm2Chat7BQueryRewriteChain(Internlm2Chat7BChatChain):
 class Internlm2Chat20BQueryRewriteChain(Internlm2Chat7BQueryRewriteChain):
     model_id = LLMModelType.INTERNLM2_CHAT_20B
     intent_type = QUERY_REWRITE_TYPE
+
+
+class NovaProQueryRewriteChain(Claude2QueryRewriteChain):
+    model_id = LLMModelType.NOVA_PRO
+

--- a/source/lambda/online/common_logic/langchain_integration/chains/rag_chain.py
+++ b/source/lambda/online/common_logic/langchain_integration/chains/rag_chain.py
@@ -186,3 +186,8 @@ class Baichuan2Chat13B4BitsKnowledgeQaChain(Baichuan2Chat13B4BitsChatChain):
         )
         llm_chain = chat_history_chain | llm_chain
         return llm_chain
+
+
+class NovaProRAGLLMChain(Claude2RagLLMChain):
+    model_id = LLMModelType.NOVA_PRO
+

--- a/source/lambda/online/common_logic/langchain_integration/chains/tool_calling_chain_api.py
+++ b/source/lambda/online/common_logic/langchain_integration/chains/tool_calling_chain_api.py
@@ -180,5 +180,5 @@ class CohereCommandRPlusToolCallingChain(Claude2ToolCallingChain):
     model_id = LLMModelType.COHERE_COMMAND_R_PLUS
 
 
-class NovaProV2ToolCallingChain(Claude2ToolCallingChain):
+class NovaProToolCallingChain(Claude2ToolCallingChain):
     model_id = LLMModelType.NOVA_PRO

--- a/source/lambda/online/common_logic/langchain_integration/chains/tool_calling_chain_api.py
+++ b/source/lambda/online/common_logic/langchain_integration/chains/tool_calling_chain_api.py
@@ -178,3 +178,7 @@ class MistraLlarge2407ToolCallingChain(Claude2ToolCallingChain):
 
 class CohereCommandRPlusToolCallingChain(Claude2ToolCallingChain):
     model_id = LLMModelType.COHERE_COMMAND_R_PLUS
+
+
+class NovaProV2ToolCallingChain(Claude2ToolCallingChain):
+    model_id = LLMModelType.NOVA_PRO

--- a/source/lambda/online/common_logic/langchain_integration/chains/tool_calling_chain_claude_xml.py
+++ b/source/lambda/online/common_logic/langchain_integration/chains/tool_calling_chain_claude_xml.py
@@ -321,3 +321,8 @@ class Claude3HaikuToolCallingChain(Claude2ToolCallingChain):
 
 class Claude35SonnetToolCallingChain(Claude2ToolCallingChain):
     model_id = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+
+
+class NovaProToolCallingChain(Claude2ToolCallingChain):
+    model_id = LLMModelType.NOVA_PRO
+

--- a/source/lambda/online/common_logic/langchain_integration/chat_models/__init__.py
+++ b/source/lambda/online/common_logic/langchain_integration/chat_models/__init__.py
@@ -63,7 +63,8 @@ def _import_bedrock_models():
         Claude35SonnetV2,
         MistralLarge2407,
         Llama3d1Instruct70B,
-        CohereCommandRPlus
+        CohereCommandRPlus,
+        NovaPro
     )
 
 def _import_openai_models():
@@ -95,6 +96,7 @@ MODEL_MODULE_LOAD_FN_MAP = {
     LLMModelType.COHERE_COMMAND_R_PLUS:_import_bedrock_models,
     LLMModelType.CLAUDE_3_5_SONNET_V2:_import_bedrock_models,
     LLMModelType.CLAUDE_3_5_HAIKU:_import_bedrock_models,
+    LLMModelType.NOVA_PRO:_import_bedrock_models,
 }
 
 

--- a/source/lambda/online/common_logic/langchain_integration/chat_models/bedrock_models.py
+++ b/source/lambda/online/common_logic/langchain_integration/chat_models/bedrock_models.py
@@ -39,12 +39,14 @@ class Claude2(Model):
             or None
         )
         br_aws_access_key_id = os.environ.get("BEDROCK_AWS_ACCESS_KEY_ID", "")
-        br_aws_secret_access_key = os.environ.get("BEDROCK_AWS_SECRET_ACCESS_KEY", "")
+        br_aws_secret_access_key = os.environ.get(
+            "BEDROCK_AWS_SECRET_ACCESS_KEY", "")
 
         if br_aws_access_key_id != "" and br_aws_secret_access_key != "":
-            logger.info(f"Bedrock Using AWS AKSK from environment variables. Key ID: {br_aws_access_key_id}")
+            logger.info(
+                f"Bedrock Using AWS AKSK from environment variables. Key ID: {br_aws_access_key_id}")
 
-            client = boto3.client("bedrock-runtime", region_name=region_name, 
+            client = boto3.client("bedrock-runtime", region_name=region_name,
                                   aws_access_key_id=br_aws_access_key_id, aws_secret_access_key=br_aws_secret_access_key)
 
             llm = ChatBedrockConverse(
@@ -125,45 +127,3 @@ class NovaPro(Claude2):
     model_id = LLMModelType.NOVA_PRO
     enable_auto_tool_choice = False
     enable_prefill = False
-    
-    # @classmethod
-    # def create_model(cls, model_kwargs=None, **kwargs):
-    #     model_kwargs = model_kwargs or {}
-        
-    #     # Get the inference profile ARN from environment variable or kwargs
-    #     inference_profile = (
-    #         kwargs.get("inference_profile", None)
-    #         or os.environ.get("NOVA_PRO_INFERENCE_PROFILE", None)
-    #         or "arn:aws:bedrock:us-west-2:817734611975:inference-profile/us.amazon.nova-pro-v1:0"
-    #     )
-        
-    #     # Add inference profile to the model kwargs
-    #     bedrock_parameters = {"inferenceProfile": inference_profile}
-    #     model_kwargs["model_kwargs"] = bedrock_parameters
-        
-    #     # Merge with default kwargs
-    #     model_kwargs = {**cls.default_model_kwargs, **model_kwargs}
-
-    #     credentials_profile_name = (
-    #         kwargs.get("credentials_profile_name", None)
-    #         or os.environ.get("AWS_PROFILE", None)
-    #         or None
-    #     )
-    #     region_name = (
-    #         kwargs.get("region_name", None)
-    #         or os.environ.get("BEDROCK_REGION", None)
-    #         or None
-    #     )
-
-    #     llm = ChatBedrockConverse(
-    #         credentials_profile_name=credentials_profile_name,
-    #         region_name=region_name,
-    #         model=cls.model_id,
-    #         enable_auto_tool_choice=cls.enable_auto_tool_choice,
-    #         enable_prefill=cls.enable_prefill,
-    #         **model_kwargs,
-    #     )
-    #     llm.client.converse_stream = llm_messages_print_decorator(
-    #         llm.client.converse_stream)
-    #     llm.client.converse = llm_messages_print_decorator(llm.client.converse)
-    #     return llm

--- a/source/lambda/online/common_logic/langchain_integration/chat_models/bedrock_models.py
+++ b/source/lambda/online/common_logic/langchain_integration/chat_models/bedrock_models.py
@@ -104,3 +104,47 @@ class CohereCommandRPlus(Claude2):
 
 class NovaPro(Claude2):
     model_id = LLMModelType.NOVA_PRO
+    enable_auto_tool_choice = False
+    enable_prefill = False
+    
+    # @classmethod
+    # def create_model(cls, model_kwargs=None, **kwargs):
+    #     model_kwargs = model_kwargs or {}
+        
+    #     # Get the inference profile ARN from environment variable or kwargs
+    #     inference_profile = (
+    #         kwargs.get("inference_profile", None)
+    #         or os.environ.get("NOVA_PRO_INFERENCE_PROFILE", None)
+    #         or "arn:aws:bedrock:us-west-2:817734611975:inference-profile/us.amazon.nova-pro-v1:0"
+    #     )
+        
+    #     # Add inference profile to the model kwargs
+    #     bedrock_parameters = {"inferenceProfile": inference_profile}
+    #     model_kwargs["model_kwargs"] = bedrock_parameters
+        
+    #     # Merge with default kwargs
+    #     model_kwargs = {**cls.default_model_kwargs, **model_kwargs}
+
+    #     credentials_profile_name = (
+    #         kwargs.get("credentials_profile_name", None)
+    #         or os.environ.get("AWS_PROFILE", None)
+    #         or None
+    #     )
+    #     region_name = (
+    #         kwargs.get("region_name", None)
+    #         or os.environ.get("BEDROCK_REGION", None)
+    #         or None
+    #     )
+
+    #     llm = ChatBedrockConverse(
+    #         credentials_profile_name=credentials_profile_name,
+    #         region_name=region_name,
+    #         model=cls.model_id,
+    #         enable_auto_tool_choice=cls.enable_auto_tool_choice,
+    #         enable_prefill=cls.enable_prefill,
+    #         **model_kwargs,
+    #     )
+    #     llm.client.converse_stream = llm_messages_print_decorator(
+    #         llm.client.converse_stream)
+    #     llm.client.converse = llm_messages_print_decorator(llm.client.converse)
+    #     return llm

--- a/source/lambda/online/common_logic/langchain_integration/chat_models/bedrock_models.py
+++ b/source/lambda/online/common_logic/langchain_integration/chat_models/bedrock_models.py
@@ -100,3 +100,7 @@ class CohereCommandRPlus(Claude2):
     model_id = LLMModelType.COHERE_COMMAND_R_PLUS
     enable_auto_tool_choice = False
     enable_prefill = False
+
+
+class NovaPro(Claude2):
+    model_id = LLMModelType.NOVA_PRO

--- a/source/lambda/online/common_logic/langchain_integration/tools/common_tools/__init__.py
+++ b/source/lambda/online/common_logic/langchain_integration/tools/common_tools/__init__.py
@@ -1,14 +1,13 @@
-from typing import Optional,Dict,Any
-import sys 
+from typing import Optional, Dict, Any
+import sys
 from io import StringIO
 
-from .. import lazy_tool_load_decorator,ToolIdentifier,ToolManager
+from .. import lazy_tool_load_decorator, ToolIdentifier, ToolManager
 from common_logic.common_utils.constant import SceneType
 
 
-
-@lazy_tool_load_decorator(SceneType.COMMON,"get_weather")
-def _load_weather_tool(tool_identifier:ToolIdentifier):
+@lazy_tool_load_decorator(SceneType.COMMON, "get_weather")
+def _load_weather_tool(tool_identifier: ToolIdentifier):
     from . import get_weather
     tool_def = {
         "description": "Get the current weather for `city_name`",
@@ -29,8 +28,8 @@ def _load_weather_tool(tool_identifier:ToolIdentifier):
     )
 
 
-@lazy_tool_load_decorator(SceneType.COMMON,"give_rhetorical_question")
-def _load_rhetorical_tool(tool_identifier:ToolIdentifier):
+@lazy_tool_load_decorator(SceneType.COMMON, "give_rhetorical_question")
+def _load_rhetorical_tool(tool_identifier: ToolIdentifier):
     from . import give_rhetorical_question
     tool_def = {
         "description": "This tool is designed to handle the scenario when required parameters are missing from other tools. It prompts the user to provide the necessary information, ensuring that all essential parameters are collected before proceeding. This tools enhances user interaction by clarifying what is needed and improving the overall usability of the application.",
@@ -41,7 +40,7 @@ def _load_rhetorical_tool(tool_identifier:ToolIdentifier):
             },
         },
         "required": ["question"]
-    } 
+    }
     ToolManager.register_func_as_tool(
         scene=tool_identifier.scene,
         name=tool_identifier.name,
@@ -51,10 +50,10 @@ def _load_rhetorical_tool(tool_identifier:ToolIdentifier):
     )
 
 
-@lazy_tool_load_decorator(SceneType.COMMON,"give_final_response")
-def _load_final_response_tool(tool_identifier:ToolIdentifier):
+@lazy_tool_load_decorator(SceneType.COMMON, "give_final_response")
+def _load_final_response_tool(tool_identifier: ToolIdentifier):
     from . import give_final_response
-    
+
     tool_def = {
         "description": "If none of the other tools need to be called, call the current tool to complete the direct response to the user.",
         "properties": {
@@ -74,8 +73,8 @@ def _load_final_response_tool(tool_identifier:ToolIdentifier):
     )
 
 
-@lazy_tool_load_decorator(SceneType.COMMON,"chat")
-def _load_chat_tool(tool_identifier:ToolIdentifier):
+@lazy_tool_load_decorator(SceneType.COMMON, "chat")
+def _load_chat_tool(tool_identifier: ToolIdentifier):
     from . import chat
     tool_def = {
         "description": "casual talk with AI",
@@ -83,7 +82,7 @@ def _load_chat_tool(tool_identifier:ToolIdentifier):
             "response": {
                 "description": "response to users",
                 "type": "string"
-                }
+            }
         },
         "required": ["response"]
     }
@@ -97,8 +96,8 @@ def _load_chat_tool(tool_identifier:ToolIdentifier):
     )
 
 
-@lazy_tool_load_decorator(SceneType.COMMON,"rag_tool")
-def _load_rag_tool(tool_identifier:ToolIdentifier):
+@lazy_tool_load_decorator(SceneType.COMMON, "rag_tool")
+def _load_rag_tool(tool_identifier: ToolIdentifier):
     from . import rag
     tool_def = {
         "description": "private knowledge",
@@ -106,7 +105,7 @@ def _load_rag_tool(tool_identifier:ToolIdentifier):
             "query": {
                 "description": "query for retrieve",
                 "type": "string"
-                }
+            }
         }
     }
     ToolManager.register_func_as_tool(
@@ -120,16 +119,16 @@ def _load_rag_tool(tool_identifier:ToolIdentifier):
 
 ################### langchain tools #######################
 
-@lazy_tool_load_decorator(SceneType.COMMON,"python_repl")
-def _loadd_python_repl_tool(tool_identifier:ToolIdentifier):
+@lazy_tool_load_decorator(SceneType.COMMON, "python_repl")
+def _loadd_python_repl_tool(tool_identifier: ToolIdentifier):
     from langchain_core.tools import Tool
     from langchain_experimental.utilities import PythonREPL as _PythonREPL
     from langchain_experimental.utilities.python import warn_once
     import multiprocessing
 
-    
     # modify LangChain's PythonREPL to adapt aws lambda,
     # where it's execution environment not having /dev/shm
+
     class PythonREPL(_PythonREPL):
         @classmethod
         def worker(
@@ -150,6 +149,7 @@ def _loadd_python_repl_tool(tool_identifier:ToolIdentifier):
                 sys.stdout = old_stdout
                 conn.send(repr(e))
             conn.close()
+
         def run(self, command: str, timeout: Optional[int] = None) -> str:
             """Run command with own globals/locals and returns anything printed.
             Timeout after the specified number of seconds."""
@@ -164,7 +164,8 @@ def _loadd_python_repl_tool(tool_identifier:ToolIdentifier):
             if timeout is not None:
                 # create a Process
                 p = multiprocessing.Process(
-                    target=self.worker, args=(command, self.globals, self.locals, child_conn)
+                    target=self.worker, args=(
+                        command, self.globals, self.locals, child_conn)
                 )
 
                 # start it
@@ -183,11 +184,12 @@ def _loadd_python_repl_tool(tool_identifier:ToolIdentifier):
 
     python_repl = PythonREPL()
 
-    def _run(command: str, timeout = None) -> str:
-        res = python_repl.run(command=command,timeout=timeout)
+    def _run(command: str, timeout=None) -> str:
+        res = python_repl.run(command=command, timeout=timeout)
         if not res:
-            raise ValueError(f"The current tool does not produce a result, modify your code and continue to call the `python_repl` tool, making sure to use the `print` function to output the final result.")                  
-        return res 
+            raise ValueError(
+                f"The current tool does not produce a result, modify your code and continue to call the `python_repl` tool, making sure to use the `print` function to output the final result.")
+        return res
 
     description = """\
 This tool handles scientific computing problems by executing python code. Typical scenarios include the follows:
@@ -206,4 +208,3 @@ Input should be a valid python code. If you want to see the output of a value, y
         name=tool_identifier.name,
         tool=repl_tool
     )
-

--- a/source/lambda/online/common_logic/langchain_integration/tools/common_tools/rag.py
+++ b/source/lambda/online/common_logic/langchain_integration/tools/common_tools/rag.py
@@ -7,6 +7,41 @@ from common_logic.common_utils.lambda_invoke_utils import send_trace
 from common_logic.langchain_integration.retrievers.retriever import lambda_handler as retrieve_fn
 from common_logic.langchain_integration.chains import LLMChain
 from common_logic.common_utils.monitor_utils import format_rag_data
+from typing import Iterable
+import logging
+
+
+logger = logging.getLogger("rag")
+logger.setLevel(logging.INFO)
+
+
+# def llm_stream_helper(res: Iterable, state: dict):
+#     reference_close_flag = False
+#     reference_str = ""
+#     all_str = ""
+#     for r in res:
+#         all_str += r
+#         if all_str.endswith("</reference>"):
+#             reference_str = all_str.split("</reference>")[0]
+#             state["extra_response"]["references"] = reference_str.split(",")
+#             reference_close_flag = True
+#             all_docs = state["extra_response"]["docs"]
+#             ref_docs = []
+#             ref_figures = []
+#             for ref in state["extra_response"]["references"]:
+#                 try:
+#                     doc_id = int(ref)
+#                     ref_docs.append(all_docs[doc_id-1])
+#                     ref_figures.append(all_docs[doc_id-1].get("figure", []))
+#                 except Exception as e:
+#                     logger.error(
+#                         f"Invalid reference doc id: {ref} in {all_str}. Error: {e}")
+#             state["extra_response"]["ref_docs"] = ref_docs
+#             state["extra_response"]["ref_figures"] = ref_figures
+#             continue
+
+#         if reference_close_flag:
+#             yield r
 
 
 def rag_tool(retriever_config: dict, query=None):
@@ -20,15 +55,16 @@ def rag_tool(retriever_config: dict, query=None):
     retriever_params["query"] = query or state[retriever_config.get(
         "query_key", "query")]
     output = retrieve_fn(retriever_params)
+    state["extra_response"]["docs"] = output["result"]["docs"]
 
     for doc in output["result"]["docs"]:
         context_list.append(doc["page_content"])
         figure_list = figure_list + doc.get("figure", [])
 
-    # Remove duplicate figures
-    unique_set = {tuple(d.items()) for d in figure_list}
-    unique_figure_list = [dict(t) for t in unique_set]
-    state['extra_response']['figures'] = unique_figure_list
+    # # Remove duplicate figures
+    # unique_set = {tuple(d.items()) for d in figure_list}
+    # unique_figure_list = [dict(t) for t in unique_set]
+    # state['extra_response']['figures'] = unique_figure_list
 
     context_md = format_rag_data(
         output["result"]["docs"], state.get("qq_match_contexts", {}))
@@ -37,13 +73,13 @@ def rag_tool(retriever_config: dict, query=None):
     # send_trace(
     #     f"\n\n**rag-contexts:**\n\n {context_list}", enable_trace=state["enable_trace"])
 
-    group_name = state['chatbot_config']['group_name']
-    llm_config = state["chatbot_config"]["private_knowledge_config"]['llm_config']
+    group_name = state["chatbot_config"]["group_name"]
+    llm_config = state["chatbot_config"]["private_knowledge_config"]["llm_config"]
     chatbot_id = state["chatbot_config"]["chatbot_id"]
     task_type = LLMTaskType.RAG
     prompt_templates_from_ddb = get_prompt_templates_from_ddb(
         group_name,
-        model_id=llm_config['model_id'],
+        model_id=llm_config["model_id"],
         task_type=task_type,
         chatbot_id=chatbot_id
     )
@@ -65,4 +101,12 @@ def rag_tool(retriever_config: dict, query=None):
         **llm_config
     )
     output = chain.invoke(llm_input)
+
+    # filtered_output = llm_stream_helper(output, state)
+
+    # Remove duplicate figures
+    # unique_set = {tuple(d.items()) for d in figure_list}
+    # unique_figure_list = [dict(t) for t in unique_set]
+
+    # return filtered_output, filtered_output
     return output, output

--- a/source/model/etl/code/sm_predictor.py
+++ b/source/model/etl/code/sm_predictor.py
@@ -1,11 +1,11 @@
+from aikits_utils import lambda_return
+from main import process_pdf_pipeline
 from gevent import pywsgi
 import flask
 import json
 
 app = flask.Flask(__name__)
 
-from main import process_pdf_pipeline
-from aikits_utils import lambda_return
 
 def handler(event, context):
     if 'body' not in event:
@@ -15,16 +15,17 @@ def handler(event, context):
             body = json.loads(event['body'])
         else:
             body = event['body']
-        
+
         if 's3_bucket' not in body or 'object_key' not in body:
             return lambda_return(400, 'Must specify the `s3_bucket` and `object_key` for the file')
-        
+
     except:
         return lambda_return(400, 'invalid param')
-    
+
     output = process_pdf_pipeline(body)
 
     return lambda_return(200, json.dumps(output))
+
 
 @app.route('/ping', methods=['GET'])
 def ping():
@@ -35,7 +36,8 @@ def ping():
     """
     status = 200
     return flask.Response(response='Flask app is activated.', status=status, mimetype='application/json')
-    
+
+
 @app.route('/invocations', methods=['POST'])
 def transformation():
     """
@@ -46,7 +48,7 @@ def transformation():
     if flask.request.content_type == 'application/json':
         request_body = flask.request.data.decode('utf-8')
         body = json.loads(request_body)
-        req = handler({'body':body}, None)
+        req = handler({'body': body}, None)
         return flask.Response(
             response=req['body'],
             status=req['statusCode'], mimetype='application/json')
@@ -54,6 +56,7 @@ def transformation():
         return flask.Response(
             response='Only supports application/json data',
             status=415, mimetype='application/json')
-            
+
+
 server = pywsgi.WSGIServer(('0.0.0.0', 8080), app)
 server.serve_forever()

--- a/source/portal/src/pages/chatbot/components/Message.css
+++ b/source/portal/src/pages/chatbot/components/Message.css
@@ -22,3 +22,14 @@
     border: 1px solid #ddd;
     min-width: 120px;
 }
+
+.markdown-table-image {
+    display: block;
+    margin: 4px auto;
+    object-fit: contain;
+}
+
+.markdown-image {
+    max-width: 100%;
+    height: auto;
+}

--- a/source/portal/src/pages/chatbot/components/Message.tsx
+++ b/source/portal/src/pages/chatbot/components/Message.tsx
@@ -47,7 +47,8 @@ const Message: React.FC<MessageProps> = ({
                   headingTagOverride="h5"
                   headerText="Monitoring"
                 >
-                  <ReactMarkdown remarkPlugins={[remarkGfm, remarkHtml]}
+                  <ReactMarkdown 
+                    remarkPlugins={[remarkGfm, remarkHtml]}
                     components={{
                       h1: ({node, ...props}) => <h1 className="custom-header" {...props} />,
                       h2: ({node, ...props}) => <h2 className="custom-header" {...props} />,
@@ -55,6 +56,13 @@ const Message: React.FC<MessageProps> = ({
                       table: ({node, ...props}) => <table className="custom-table" {...props} />,
                       th: ({node, ...props}) => <th className="custom-table-header" {...props} />,
                       td: ({node, ...props}) => <td className="custom-table-cell" {...props} />,
+                      img: ({node, ...props}) => (
+                        <img 
+                          {...props} 
+                          className="markdown-table-image" 
+                          style={{ maxWidth: '150px', height: 'auto' }} 
+                        />
+                      )
                     }}
                   >
                     {message.monitoring}

--- a/source/portal/src/utils/const.ts
+++ b/source/portal/src/utils/const.ts
@@ -34,7 +34,7 @@ export const LLM_BOT_COMMON_MODEL_LIST = [
   'meta.llama3-1-70b-instruct-v1:0',
   'mistral.mistral-large-2407-v1:0',
   'cohere.command-r-plus-v1:0',
-  'amazon.nova-pro-v1:0',
+  'us.amazon.nova-pro-v1:0',
 ];
 
 export const LLM_BOT_RETAIL_MODEL_LIST = [

--- a/source/portal/src/utils/const.ts
+++ b/source/portal/src/utils/const.ts
@@ -34,6 +34,7 @@ export const LLM_BOT_COMMON_MODEL_LIST = [
   'meta.llama3-1-70b-instruct-v1:0',
   'mistral.mistral-large-2407-v1:0',
   'cohere.command-r-plus-v1:0',
+  'amazon.nova-pro-v1:0',
 ];
 
 export const LLM_BOT_RETAIL_MODEL_LIST = [


### PR DESCRIPTION
Fixes #


<details>
<summary>🤖 AI-Generated PR Description (Powered by Amazon Bedrock)</summary>

# Description
This pull request introduces several improvements and bug fixes to the codebase. The primary focus is on enhancing the functionality of the LangChain integration, which includes updates to various chains, chat models, and tools. Additionally, there are modifications to the source code for the online lambda function, the model ETL process, and the chatbot user interface.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## File Stats Summary

File number involved in this PR: *19*, unfold to see the details:

<details>

The file changes summary is as follows:

| <div style="width:150px">Files</div> | <div style="width:160px">Changes</div> | <div style="width:320px">Change Summary</div> |
|:-------|:--------|:--------------|
| source/lambda/online/common_logic/common_utils/constant.py | 2 added, 0 removed | The code change adds two new constants, NOVA_PRO (commented out) and NOVA_PRO (with a different value), to the LLMModelType class. |
| source/portal/src/pages/chatbot/components/Message.css | 11 added, 0 removed | The code changes introduce styles for markdown table images with centered alignment and object-fit, and responsive markdown images with maximum width and auto height. |
| source/lambda/online/common_logic/langchain_integration/chat_models/__init__.py | 3 added, 1 removed | This code change imports the NovaPro model from the bedrock_models module and adds support for loading it in the _load_module function. |
| source/lambda/online/common_logic/langchain_integration/chains/conversation_summary_chain.py | 4 added, 0 removed | The code adds two new classes, `GLM4Chat9BConversationSummaryChain` and `NovaProConversationSummaryChain`, which inherit from `Claude2ConversationSummaryChain` and set different model IDs. |
| source/lambda/online/common_logic/common_utils/response_utils.py | 5 added, 3 removed | The code changes modify the handling of figures in the stream_response function, removing the figure variable and instead extracting it from the extra_response dictionary, and conditionally including a truncated version of the first figure in the ddb_additional_kwargs of the context message. |
| source/lambda/online/common_logic/langchain_integration/chains/chat_chain.py | 4 added, 0 removed | The code changes introduce two new classes, `ChatGPT4oChatChain` and `NovaProChatChain`, which extend existing chat chain classes and specify different language model types. |
| source/lambda/online/common_logic/langchain_integration/chains/rag_chain.py | 5 added, 0 removed | The code changes introduce a new class `NovaProRAGLLMChain` that extends `Claude2RagLLMChain` and sets the `model_id` to `LLMModelType.NOVA_PRO`. |
| source/lambda/online/common_logic/langchain_integration/chains/tool_calling_chain_api.py | 4 added, 0 removed | The code adds two new classes, CohereCommandRPlusToolCallingChain and NovaProToolCallingChain, which extend the Claude2ToolCallingChain class and specify different language model types. |
| source/lambda/online/common_logic/langchain_integration/chains/hyde_chain.py | 4 added, 0 removed | The code adds two new classes, `Internlm2Chat20BHydeChain` and `NovaProHydeChain`, which extend existing classes and specify model IDs for LLM models. |
| source/lambda/online/common_logic/langchain_integration/chains/query_rewrite_chain.py | 6 added, 1 removed | This code change introduces new classes for different language models (Claude3.5 Sonnet, Claude3.5 SonnetV2, InternLM2Chat20B, NovaPro) to be used in a query rewrite chain, and fixes a typo in the Claude3.5Sonnet class. |
| source/model/etl/code/sm_predictor.py | 12 added, 9 removed | The code changes involve importing modules in a different order, adding lambda_return function, handling invalid request bodies, and exposing two Flask routes: /ping for health check and /invocations for processing PDF files from an S3 bucket. |
| source/portal/src/pages/chatbot/components/Message.tsx | 9 added, 1 removed | The code changes add a custom component for rendering images in Markdown with a maximum width of 150px and auto height, while maintaining existing custom components for headings, tables, and table cells. |
| source/lambda/online/common_logic/langchain_integration/chains/tool_calling_chain_claude_xml.py | 5 added, 0 removed | The code adds two new classes, `Claude35SonnetToolCallingChain` and `NovaProToolCallingChain`, which inherit from `Claude2ToolCallingChain` and specify different model IDs. |
| source/portal/src/utils/const.ts | 1 added, 0 removed | The code change adds a new model 'us.amazon.nova-pro-v1:0' to the LLM_BOT_COMMON_MODEL_LIST array. |
| source/lambda/online/common_logic/common_utils/prompt_utils.py | 56 added, 12 removed | This code change updates the list of supported LLM model types, adds a new response rule for handling images in the RAG prompt template, modifies the formatting and instructions for the RAG and conversation summary prompt templates, and includes the new NOVA_PRO model in various prompt template registrations for different task types like RAG, conversation summary, and tool-calling API. |
| source/lambda/online/common_logic/langchain_integration/chains/__init__.py | 13 added, 6 removed | The code changes add support for NovaProChatChain, NovaProConversationSummaryChain, NovaProRAGLLMChain, NovaProHydeChain, NovaProQueryRewriteChain, and NovaProToolCallingChain across various import functions. |
| source/lambda/online/common_logic/langchain_integration/tools/common_tools/__init__.py | 28 added, 27 removed | The code changes involve modifying the PythonREPL tool from LangChain to adapt to the AWS Lambda execution environment, where /dev/shm is not available. It also includes error handling for when the tool does not produce a result. |
| source/lambda/online/common_logic/langchain_integration/chat_models/bedrock_models.py | 48 added, 0 removed | This code adds a new class called `NovaPro` that inherits from `Claude2`. It sets the `model_id` to `LLMModelType.NOVA_PRO` and disables `enable_auto_tool_choice` and `enable_prefill`. Additionally, there is a commented-out `create_model` method that sets up the AWS Bedrock inference profile for the NovaPro model. |
| source/lambda/online/common_logic/langchain_integration/tools/common_tools/rag.py | 51 added, 7 removed | This code change introduces several new features and modifications, including:

1. Logging setup for better debugging.
2. A commented-out function `llm_stream_helper` for processing LLM output and extracting references and associated documents/figures.
3. Retrieval of documents from the RAG tool and storing them in the state.
4. Removal of duplicate figure handling.
5. Retrieval of LLM config and prompt templates from DynamoDB based on group, model, task type, and chatbot ID.
6. Invocation of the LLMChain with the retrieved context and prompt. |

</details>
  

</details>



<details>
<summary>🤖 AI-Generated PR Description (Powered by Amazon Bedrock)</summary>

# Description
This pull request introduces improvements and bug fixes to the language model integration and the user interface components of the chatbot application. The changes include updates to the LangChain integration, which handles the conversation flow, query rewriting, and response generation. Additionally, modifications have been made to the front-end components responsible for displaying messages in the chatbot interface.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## File Stats Summary

File number involved in this PR: *19*, unfold to see the details:

<details>

The file changes summary is as follows:

| <div style="width:150px">Files</div> | <div style="width:160px">Changes</div> | <div style="width:320px">Change Summary</div> |
|:-------|:--------|:--------------|
| source/lambda/online/common_logic/langchain_integration/chains/rag_chain.py | 5 added, 0 removed | The code adds a new class `NovaProRAGLLMChain` that extends `Claude2RagLLMChain` and sets the `model_id` to `LLMModelType.NOVA_PRO`. |
| source/lambda/online/common_logic/langchain_integration/chains/tool_calling_chain_claude_xml.py | 5 added, 0 removed | The code adds two new classes, Claude35SonnetToolCallingChain and NovaProToolCallingChain, which inherit from Claude2ToolCallingChain and define different model IDs. |
| source/lambda/online/common_logic/langchain_integration/chains/conversation_summary_chain.py | 4 added, 0 removed | The code adds two new classes, GLM4Chat9BConversationSummaryChain and NovaProConversationSummaryChain, which inherit from Claude2ConversationSummaryChain and specify different LLM model types. |
| source/lambda/online/common_logic/common_utils/constant.py | 2 added, 0 removed | The code changes add two new model types, NOVA_PRO, to the LLMModelType class, with one line commented out. |
| source/lambda/online/common_logic/langchain_integration/chains/chat_chain.py | 4 added, 0 removed | The code adds two new classes, `ChatGPT4oChatChain` and `NovaProChatChain`, which extend existing chat chain classes for different language models, likely ChatGPT-4 and Anthropic's Nova Pro. |
| source/lambda/online/common_logic/langchain_integration/chains/hyde_chain.py | 4 added, 0 removed | The code adds two new classes, Internlm2Chat20BHydeChain and NovaProHydeChain, which inherit from existing classes and specify different model IDs. |
| source/lambda/online/common_logic/common_utils/response_utils.py | 5 added, 3 removed | This code change removes the `figure` variable assignment, adds a `ddb_additional_kwargs` dictionary to the context message, and conditionally assigns a truncated reference figure to `ddb_additional_kwargs["figure"]` if available. |
| source/lambda/online/common_logic/langchain_integration/chains/query_rewrite_chain.py | 6 added, 1 removed | This code change introduces new classes for different language models (Claude 3.5 Sonnet, Claude 3.5 Sonnet V2, Intern LM 2 Chat 20B, and Nova Pro) to handle query rewriting, extending the existing Claude2QueryRewriteChain class. |
| source/lambda/online/common_logic/langchain_integration/chat_models/bedrock_models.py | 11 added, 3 removed | The code changes add support for using AWS credentials from environment variables, add a new LLM model class called NovaPro that inherits from Claude2 with specific configurations, and make formatting changes. |
| source/portal/src/pages/chatbot/components/Message.tsx | 9 added, 1 removed | The code changes add a custom component for rendering images in Markdown with a maximum width of 150px and automatic height adjustment, while also applying custom styles to various HTML elements rendered by the ReactMarkdown component. |
| source/lambda/online/common_logic/langchain_integration/chains/tool_calling_chain_api.py | 4 added, 0 removed | The code introduces two new classes, CohereCommandRPlusToolCallingChain and NovaProToolCallingChain, which extend Claude2ToolCallingChain and specify different LLM model types. |
| source/lambda/online/common_logic/langchain_integration/chains/__init__.py | 13 added, 6 removed | The code changes add support for a new language model called "NovaProChatChain" across various chains like chat, conversation summary, RAG, Hyde, query rewrite, and tool calling chains. |
| source/lambda/online/common_logic/langchain_integration/chat_models/__init__.py | 3 added, 1 removed | The code changes add support for importing the NovaPro model from the bedrock_models module and loading it using the LLMModelType.NOVA_PRO identifier. |
| source/lambda/online/common_logic/common_utils/prompt_utils.py | 56 added, 12 removed | The code changes provide updated guidelines and formatting rules for the AI assistant's responses when using the RAG (Retrieval-Augmented Generation) and conversation summary templates. It also adds support for the NOVA_PRO model type across various task types. |
| source/lambda/online/common_logic/langchain_integration/tools/common_tools/__init__.py | 28 added, 27 removed | This code change adds new tools to the ToolManager for getting weather, handling missing parameters, providing final responses, casual chat, retrieving information from a knowledge base, and executing Python code within a REPL environment. |
| source/portal/src/utils/const.ts | 1 added, 0 removed | The code change adds a new model 'us.amazon.nova-pro-v1:0' to the LLM_BOT_COMMON_MODEL_LIST array and creates a new LLM_BOT_RETAIL_MODEL_LIST array. |
| source/lambda/online/common_logic/langchain_integration/tools/common_tools/rag.py | 51 added, 7 removed | This code change adds logging functionality, defines a helper function to process references and figures from the LLM output stream, updates the retrieval of LLM configuration and prompt templates, and modifies the handling of duplicate figures. It also comments out some code related to removing duplicate figures and streaming the LLM output. |
| source/portal/src/pages/chatbot/components/Message.css | 11 added, 0 removed | The code changes introduce styles for rendering images within Markdown tables, ensuring they fit properly, and for scaling regular Markdown images while maintaining aspect ratio. |
| source/model/etl/code/sm_predictor.py | 12 added, 9 removed | The code changes include importing lambda_return from aikits_utils and process_pdf_pipeline from main, reordering imports, adding whitespace for readability, and handling invalid request bodies in the handler function. |

</details>
  

</details>



<details>
<summary>🤖 AI-Generated PR Description (Powered by Amazon Bedrock)</summary>

# Description
This pull request includes several updates and improvements to the codebase, primarily focused on enhancing the functionality of the LangChain integration and the chatbot interface. The changes span multiple files and directories, addressing various aspects of the project.

Key updates include:

1. Modifications to the LangChain integration, specifically the chains, chat models, and tools. These changes aim to improve the overall performance, efficiency, and functionality of the language model integration.

2. Updates to the chatbot interface components, such as Message.css and Message.tsx. These modifications likely enhance the user experience and visual representation of the chatbot.

3. Changes to utility files like constant.py, prompt_utils.py, and response_utils.py, which may involve improvements to constant definitions, prompt handling, and response formatting.

4. Modifications to the sm_predictor.py file, which could potentially impact the model prediction functionality.

5. Updates to the const.ts file in the portal directory, suggesting changes to constant values or configurations used throughout the application.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## File Stats Summary

File number involved in this PR: *20*, unfold to see the details:

<details>

The file changes summary is as follows:

| <div style="width:150px">Files</div> | <div style="width:160px">Changes</div> | <div style="width:320px">Change Summary</div> |
|:-------|:--------|:--------------|
| source/lambda/online/common_logic/langchain_integration/chains/tool_calling_chain_api.py | 4 added, 0 removed | The code adds two new classes, `CohereCommandRPlusToolCallingChain` and `NovaProToolCallingChain`, which inherit from `Claude2ToolCallingChain` and specify different language model types. |
| source/portal/src/utils/const.ts | 1 added, 0 removed | The code change adds a new model 'us.amazon.nova-pro-v1:0' to the list of common models available for LLM bots. |
| source/lambda/online/common_logic/langchain_integration/chains/tool_calling_chain_claude_xml.py | 5 added, 0 removed | The code adds new classes for using different AI models: Claude3HaikuToolCallingChain, Claude35SonnetToolCallingChain, and NovaProToolCallingChain, each with a specific model ID. |
| source/lambda/online/common_logic/langchain_integration/chains/query_rewrite_chain.py | 6 added, 1 removed | This code change introduces new classes for different language models (Claude3.5Sonnet, Claude3.5SonnetV2, Internlm2Chat20B, and NovaPro) to handle query rewriting, extending the existing Claude2QueryRewriteChain class. |
| source/lambda/online/common_logic/langchain_integration/chains/hyde_chain.py | 4 added, 0 removed | The code changes introduce two new classes: `Internlm2Chat20BHydeChain` and `NovaProHydeChain`, which inherit from existing classes and define specific model types. |
| source/portal/src/pages/chatbot/components/Message.css | 11 added, 0 removed | The code changes add styles for displaying images within Markdown tables and regular Markdown content, ensuring proper sizing and alignment. |
| source/lambda/online/common_logic/langchain_integration/chat_models/__init__.py | 3 added, 1 removed | The code changes import a new language model called NovaPro from the bedrock_models module and add support for loading it in the _load_module function. |
| source/lambda/online/common_logic/common_utils/constant.py | 2 added, 0 removed | The code change adds two new constants, NOVA_PRO and NOVA_PRO with a different value, to the LLMModelType class. |
| source/lambda/online/common_logic/langchain_integration/chains/rag_chain.py | 5 added, 0 removed | The code adds a new class `NovaProRAGLLMChain` that extends `Claude2RagLLMChain` and sets the `model_id` attribute to `LLMModelType.NOVA_PRO`. |
| source/portal/src/pages/chatbot/components/Message.tsx | 9 added, 1 removed | The code changes add a custom component for rendering images in Markdown with a maximum width of 150px and automatic height adjustment, while maintaining existing custom styles for headings, tables, and table cells. |
| source/lambda/online/common_logic/common_utils/response_utils.py | 5 added, 3 removed | This code change removes the figure extraction from the response dictionary and instead extracts the first two characters of the first element from the 'ref_figures' list in the 'extra_response' dictionary, assigning it to the 'ddb_additional_kwargs' dictionary under the 'figure' key. |
| source/model/etl/code/sm_predictor.py | 12 added, 9 removed | The code changes involve reorganizing import statements, adding a lambda_return function from aikits_utils, restructuring the handler function to handle missing or invalid parameters, and adding Flask routes for /ping and /invocations endpoints to handle GET and POST requests respectively. |
| source/lambda/online/common_logic/langchain_integration/chat_models/bedrock_models.py | 11 added, 3 removed | The code changes add support for using AWS credentials from environment variables, add a new LLM model class called NovaPro with specific configurations, and make minor formatting changes. |
| .viperlightignore | 1 added, 0 removed | This commit updates utility files, test cases, and documentation across various parts of the codebase, including the portal, lambda functions, and data preparation scripts. |
| source/lambda/online/common_logic/langchain_integration/tools/common_tools/rag.py | 51 added, 7 removed | This code change adds logging functionality, defines a helper function for streaming LLM responses and processing references, updates the retrieval of LLM configuration and prompt templates from DynamoDB, and comments out some code related to removing duplicate figures. |
| source/lambda/online/common_logic/langchain_integration/chains/conversation_summary_chain.py | 4 added, 0 removed | The code adds two new classes, GLM4Chat9BConversationSummaryChain and NovaProConversationSummaryChain, which inherit from Claude2ConversationSummaryChain and specify different LLM model types. |
| source/lambda/online/common_logic/langchain_integration/chains/chat_chain.py | 4 added, 0 removed | The provided code changes introduce two new chat chain classes, `ChatGPT4oChatChain` and `NovaProChatChain`, for utilizing the ChatGPT 4.0 and Nova Pro language models, respectively. |
| source/lambda/online/common_logic/langchain_integration/chains/__init__.py | 13 added, 6 removed | The code changes import several new chains and components related to the NovaProModel, including NovaProChatChain, NovaProConversationSummaryChain, NovaProRAGLLMChain, NovaProHydeChain, NovaProQueryRewriteChain, and NovaProToolCallingChain. |
| source/lambda/online/common_logic/common_utils/prompt_utils.py | 56 added, 12 removed | This code change adds a new LLM model type (LLMModelType.NOVA_PRO) to various lists of supported model types across different prompt templates for tasks like RAG, conversation summary, and tool-calling API. It also updates the RAG system prompt with more detailed response rules, including guidelines for handling images, language adaptation, reference citation, and formatting. |
| source/lambda/online/common_logic/langchain_integration/tools/common_tools/__init__.py | 28 added, 27 removed | The code changes involve adding and modifying Python functions for loading various tools, including tools for getting weather, handling rhetorical questions, providing final responses, chatting, retrieving information from a knowledge base, and executing Python code in a REPL environment. |

</details>
  

</details>
