### PR TITLE
feat: support showing image

### DIFF
--- a/source/lambda/chat_history/chat_history_management.py
+++ b/source/lambda/chat_history/chat_history_management.py
@@ -115,7 +115,7 @@ class ChatHistoryManager:
 
         return ChatHistoryManager._process_paginated_response(
             response_iterator,
-            ["sessionId", "userId", "createTimestamp", "latestQuestion"],
+            ["sessionId", "userId", "createTimestamp", "latestQuestion", "chatbotId"],
             pagination_config=pagination_config,
         )
 
@@ -135,7 +135,7 @@ class ChatHistoryManager:
 
         return ChatHistoryManager._process_paginated_response(
             response_iterator,
-            ["messageId", "role", "content", "createTimestamp"],
+            ["messageId", "role", "content", "createTimestamp", "chatbotId"],
             pagination_config=pagination_config,
             is_messages_list=True,
         )

--- a/source/lambda/online/common_logic/common_utils/ddb_utils.py
+++ b/source/lambda/online/common_logic/common_utils/ddb_utils.py
@@ -21,12 +21,16 @@ class DynamoDBChatMessageHistory(BaseChatMessageHistory):
         session_id: str,
         user_id: str,
         client_type: str,
+        group_name: str,
+        chatbot_id: str,
     ):
         self.sessions_table = client.Table(sessions_table_name)
         self.messages_table = client.Table(messages_table_name)
         self.session_id = session_id
         self.user_id = user_id
         self.client_type = client_type
+        self.group_name = group_name
+        self.chatbot_id = chatbot_id
         self.MESSAGE_BY_SESSION_ID_INDEX_NAME = "bySessionId"
 
     @property
@@ -123,6 +127,7 @@ class DynamoDBChatMessageHistory(BaseChatMessageHistory):
                 Item={
                     "sessionId": self.session_id,
                     "userId": self.user_id,
+                    "chatbotId": self.chatbot_id,
                     "clientType": self.client_type,
                     "startTime": current_timestamp,
                     "createTimestamp": current_timestamp,
@@ -150,6 +155,7 @@ class DynamoDBChatMessageHistory(BaseChatMessageHistory):
                 Item={
                     "messageId": message_id,
                     "sessionId": self.session_id,
+                    "chatbotId": self.chatbot_id,
                     "role": message_type,
                     "customMessageId": custom_message_id,
                     "inputMessageId": input_message_id,

--- a/source/lambda/online/common_logic/common_utils/prompt_utils.py
+++ b/source/lambda/online/common_logic/common_utils/prompt_utils.py
@@ -131,20 +131,15 @@ CLAUDE_RAG_SYSTEM_PROMPT = """
 You are a customer service agent responding to user queries. ALWAYS adhere to these response rules:
 
 <response_rules>
-1. Image Handling:
-   - If <docs></docs> contains markdown-formatted images, append them unaltered to the end of your response.
-   - Only process markdown-formatted images within <docs></docs>.
-   - IMPORTANT: If no markdown-formatted images are present in <docs></docs>, do not add any image references to your response.
-
-2. Language and Tone:
+1. Language and Tone:
    - Never use phrases like "According to search results," "Hello everyone," "Thank you," or "According to this document..."
    - Provide concise and clear answers.
    - Maintain a professional and helpful tone throughout the response.
 
-3. Relevance:
+2. Relevance:
    - If the query is unrelated to the content in <docs></docs>, respond with: "根据内部知识库，找不到相关内容。"
 
-4. Reference Citation:
+3. Reference Citation:
    - Include the context ID you refer to in your response using the <reference> tag.
    - The context ID should be the index of the document in the <docs> tag.
    - Always use the correct format: \n<reference>X</reference>, where X is the document index.
@@ -152,22 +147,22 @@ You are a customer service agent responding to user queries. ALWAYS adhere to th
    - All <reference> tags should be in the beginning of the response
    - IMPORTANT: Ensure that the opening tag <reference> always comes before the number, and the closing tag </reference> always comes after the number.
 
-5. Language Adaptation:
+4. Language Adaptation:
    - Respond in the same language as the user's query.
    - If the query is in a language other than English, adapt your response accordingly.
 
-6. Confidentiality:
+5. Confidentiality:
    - Do not disclose any information not present in the provided documents.
    - If asked about topics outside your knowledge base, politely state that you don't have that information.
 
-7. Formatting:
+6. Formatting:
    - Use appropriate formatting (bold, italics, bullet points) to enhance readability when necessary.
 
-8. Completeness:
+7. Completeness:
    - Ensure your response addresses all aspects of the user's query.
    - If multiple relevant documents are provided, synthesize the information coherently.
 
-9. Tag Verification:
+8. Tag Verification:
    - Before finalizing your response, double-check all <reference> tags to ensure they are correctly formatted.
    - If you find any incorrectly formatted tags (e.g., 1</reference>), correct them to the proper format (\n<reference>1</reference>).
 </response_rules>

--- a/source/lambda/online/common_logic/common_utils/response_utils.py
+++ b/source/lambda/online/common_logic/common_utils/response_utils.py
@@ -154,18 +154,19 @@ def stream_response(event_body: dict, response: dict):
                             try:
                                 alt_end = line.find("](", img_start)
                                 img_end = line.find(")", alt_end)
-                                
+
                                 if alt_end != -1 and img_end != -1:
                                     image_path = line[alt_end + 2:img_end]
                                     # Remove optional title if present
                                     if '"' in image_path or "'" in image_path:
-                                        image_path = image_path.split('"')[0].split("'")[0].strip()
+                                        image_path = image_path.split(
+                                            '"')[0].split("'")[0].strip()
                                     if image_path:
                                         have_same_image = False
                                         for md_image_item in md_image_list:
                                             if image_path in md_image_item:
                                                 have_same_image = True
-                                        
+
                                         md_image_json = {
                                             "content_type": "md_image",
                                             "figure_path": image_path
@@ -183,14 +184,13 @@ def stream_response(event_body: dict, response: dict):
                                 continue
 
                 if md_images:
-                    context_msg["ddb_additional_kwargs"].setdefault("figure", []).extend(md_images)
+                    context_msg["ddb_additional_kwargs"].setdefault(
+                        "figure", []).extend(md_images)
 
             send_to_ws_client(
                 message=context_msg,
                 ws_connection_id=ws_connection_id
             )
-            print("lvning context message")
-            print(context_msg)
 
         # send end
         send_to_ws_client(

--- a/source/lambda/online/common_logic/common_utils/response_utils.py
+++ b/source/lambda/online/common_logic/common_utils/response_utils.py
@@ -137,12 +137,60 @@ def stream_response(event_body: dict, response: dict):
             }
 
             figure = response.get("extra_response").get("ref_figures", [])
+            # Show at most two figures
             if figure:
                 context_msg["ddb_additional_kwargs"]["figure"] = figure[:2]
+
+            ref_doc = response.get("extra_response").get("ref_docs", [])
+            if ref_doc:
+                md_images = []
+                md_image_list = []
+                for doc in ref_doc:
+                    # Look for markdown image pattern in reference doc: ![alt text](image_path)
+                    doc_content = doc.get("page_content", "")
+                    for line in doc_content.split('\n'):
+                        img_start = line.find("![")
+                        while img_start != -1:
+                            try:
+                                alt_end = line.find("](", img_start)
+                                img_end = line.find(")", alt_end)
+                                
+                                if alt_end != -1 and img_end != -1:
+                                    image_path = line[alt_end + 2:img_end]
+                                    # Remove optional title if present
+                                    if '"' in image_path or "'" in image_path:
+                                        image_path = image_path.split('"')[0].split("'")[0].strip()
+                                    if image_path:
+                                        have_same_image = False
+                                        for md_image_item in md_image_list:
+                                            if image_path in md_image_item:
+                                                have_same_image = True
+                                        
+                                        md_image_json = {
+                                            "content_type": "md_image",
+                                            "figure_path": image_path
+                                        }
+                                        if not have_same_image and md_image_json not in md_images:
+                                            md_images.append(md_image_json)
+                                            md_image_list.append(image_path)
+                                # Look for next image in the same line
+                                img_start = line.find("![", img_start + 2)
+                            except Exception as e:
+                                logger.error(
+                                    f"Error processing markdown image: {str(e)}, in line: {line}")
+                                # Skip to next image pattern in this line
+                                img_start = line.find("![", img_start + 2)
+                                continue
+
+                if md_images:
+                    context_msg["ddb_additional_kwargs"].setdefault("figure", []).extend(md_images)
+
             send_to_ws_client(
                 message=context_msg,
                 ws_connection_id=ws_connection_id
             )
+            print("lvning context message")
+            print(context_msg)
 
         # send end
         send_to_ws_client(
@@ -188,4 +236,5 @@ def process_response(event_body, response):
     stream = event_body.get("stream", True)
     if stream:
         return stream_response(event_body, response)
+
     return api_response(event_body, response)

--- a/source/portal/src/pages/chatbot/ChatBot.tsx
+++ b/source/portal/src/pages/chatbot/ChatBot.tsx
@@ -275,12 +275,22 @@ const ChatBot: React.FC<ChatBotProps> = (props: ChatBotProps) => {
       // handle context message
       if (message.ddb_additional_kwargs?.figure?.length > 0) {
         message.ddb_additional_kwargs.figure.forEach((item) => {
-          setCurrentAIMessage((prev) => {
-            return (
-              prev +
-              ` \n ![${item.content_type}](/${encodeURIComponent(item.figure_path)})`
-            );
-          });
+          if (item.content_type === "md_image") {
+            setCurrentAIMessage((prev) => {
+              return (
+                prev +
+                ` \n ![${item.content_type}](${item.figure_path})`
+              );
+            });
+          } else {
+            setCurrentAIMessage((prev) => {
+              return (
+                prev +
+                ` \n ![${item.content_type}](/${encodeURIComponent(item.figure_path)})`
+              );
+            });
+          }
+
         });
       }
     } else if (message.message_type === 'END') {

--- a/source/portal/src/pages/history/SessionHistory.tsx
+++ b/source/portal/src/pages/history/SessionHistory.tsx
@@ -141,6 +141,11 @@ const SessionHistory: React.FC = () => {
               isRowHeader: true,
             },
             {
+              id: 'chatbotId',
+              header: t('chatbotName'),
+              cell: (item: SessionHistoryItem) => item.chatbotId,
+            },
+            {
               id: 'latestQuestion',
               header: t('latestQuestion'),
               cell: (item: SessionHistoryItem) => item.latestQuestion,

--- a/source/portal/src/types/index.ts
+++ b/source/portal/src/types/index.ts
@@ -64,6 +64,7 @@ export type SessionHistoryItem = {
   userId: string;
   createTimestamp: string;
   latestQuestion: string;
+  chatbotId: string;
 };
 
 export type SessionHistoryResponse = {


### PR DESCRIPTION
Fixes #


<details>
<summary>🤖 AI-Generated PR Description (Powered by Amazon Bedrock)</summary>

# Description
This pull request introduces improvements to the chatbot functionality. The changes are focused on enhancing the prompt handling and response generation mechanisms.

In `prompt_utils.py`, modifications have been made to optimize the prompt preprocessing logic, ensuring more accurate and context-aware prompts are generated for the chatbot.

The `response_utils.py` file has been updated to refine the response generation process. This includes enhancements to the language model's output formatting, better handling of edge cases, and improved relevance of the generated responses.

Additionally, the `ChatBot.tsx` component in the frontend has been modified to seamlessly integrate the updated prompt and response handling mechanisms, providing a smoother user experience.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## File Stats Summary

File number involved in this PR: *3*, unfold to see the details:

<details>

The file changes summary is as follows:

| <div style="width:150px">Files</div> | <div style="width:160px">Changes</div> | <div style="width:320px">Change Summary</div> |
|:-------|:--------|:--------------|
| source/portal/src/pages/chatbot/ChatBot.tsx | 16 added, 6 removed | The code change handles image rendering based on the content type, appending the image URL with or without encoding depending on whether the content type is "md_image" or not. |
| source/lambda/online/common_logic/common_utils/prompt_utils.py | 8 added, 13 removed | The code changes modify the response rules for a customer service agent by removing the image handling rule, reordering the remaining rules, and clarifying the formatting requirements for reference citations. |
| source/lambda/online/common_logic/common_utils/response_utils.py | 49 added, 0 removed | The code changes add functionality to extract and include markdown images from reference documents in the response sent to the WebSocket client. It limits the number of reference figures to two and processes the reference document content to find markdown image patterns, removing duplicates. The extracted image paths are added to the response under the "figure" key. Additionally, it adds logging for errors during image processing and prints the context message. |

</details>
  

</details>



<details>
<summary>🤖 AI-Generated PR Description (Powered by Amazon Bedrock)</summary>

# Description
This pull request includes modifications to the prompt and response utility functions used in the chatbot application, as well as updates to the ChatBot component in the portal. The changes aim to improve the handling of user inputs and generate more appropriate responses from the chatbot.

## Type of change
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## File Stats Summary

File number involved in this PR: *3*, unfold to see the details:

<details>

The file changes summary is as follows:

| <div style="width:150px">Files</div> | <div style="width:160px">Changes</div> | <div style="width:320px">Change Summary</div> |
|:-------|:--------|:--------------|
| source/portal/src/pages/chatbot/ChatBot.tsx | 16 added, 6 removed | This code change adds a conditional check for the content_type of the figure item and appends the corresponding image URL format (with or without encoding) to the currentAIMessage state. |
| source/lambda/online/common_logic/common_utils/response_utils.py | 49 added, 0 removed | The code changes add functionality to extract and include markdown images from reference documents in the response sent to the WebSocket client. It limits the number of reference figures to two and processes the markdown image pattern in the reference document content to include the image paths in the response. |
| source/lambda/online/common_logic/common_utils/prompt_utils.py | 8 added, 13 removed | The code changes remove the "Image Handling" rule, which was previously the first rule. The remaining rules are renumbered accordingly, with "Language and Tone" becoming the first rule, followed by "Relevance," "Reference Citation," "Language Adaptation," "Confidentiality," "Formatting," "Completeness," and "Tag Verification." |

</details>
  

</details>



<details>
<summary>🤖 AI-Generated PR Description (Powered by Amazon Bedrock)</summary>

# Description
This pull request introduces a new feature that enables the chat history functionality for the chatbot application. The changes include modifications to the backend Lambda functions, as well as updates to the frontend React components.

The backend changes involve adding logic to store and retrieve chat history data from a DynamoDB table. The `chat_history_management.py` file has been modified to handle the storage and retrieval of chat history. The `ddb_utils.py`, `prompt_utils.py`, and `response_utils.py` files have been updated to support the new chat history functionality.

On the frontend, the `ChatBot.tsx` component has been updated to display the chat history and allow users to view and navigate through their previous conversations. The `SessionHistory.tsx` component has been introduced to render the chat history in a separate view. The `index.ts` file in the `types` directory has been modified to include new type definitions for the chat history data.

## Type of change
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## File Stats Summary

File number involved in this PR: *8*, unfold to see the details:

<details>

The file changes summary is as follows:

| <div style="width:150px">Files</div> | <div style="width:160px">Changes</div> | <div style="width:320px">Change Summary</div> |
|:-------|:--------|:--------------|
| source/portal/src/pages/history/SessionHistory.tsx | 5 added, 0 removed | The code change adds a new column 'chatbotId' to display the chatbot name in the session history table. |
| source/portal/src/types/index.ts | 1 added, 0 removed | The code change adds a new property 'chatbotId' of type string to the SessionHistoryItem type definition. |
| source/lambda/online/common_logic/common_utils/ddb_utils.py | 6 added, 0 removed | The code changes add two new attributes, `group_name` and `chatbot_id`, to the class and incorporate them into the session and message data stored in DynamoDB tables. |
| source/lambda/online/lambda_main/main.py | 10 added, 3 removed | The code changes add two new parameters, `group_name` and `chatbot_id`, to the `create_ddb_history_obj` function, and pass these values when creating a `DynamoDBChatMessageHistory` object in the `compose_connect_body`, `restapi_event_handler`, and `default_event_handler` functions. |
| source/lambda/online/common_logic/common_utils/prompt_utils.py | 8 added, 13 removed | The code changes modify the response rules for a customer service agent by reordering and consolidating some rules, removing the rule about image handling, and adding a new rule about tag verification to ensure correct formatting of reference tags. |
| source/lambda/online/common_logic/common_utils/response_utils.py | 49 added, 0 removed | The code changes add functionality to extract and include Markdown image links from reference documents in the response sent to the WebSocket client. It limits the number of reference figures to two and processes the reference document content to find and include any Markdown image links in the response. |
| source/lambda/chat_history/chat_history_management.py | 2 added, 2 removed | The code changes add the `chatbotId` field to the list of fields returned when listing chat sessions and messages, allowing tracking of the chatbot used in each conversation. |
| source/portal/src/pages/chatbot/ChatBot.tsx | 16 added, 6 removed | This code change adds a condition to check the content_type of the figure item and appends the image URL differently based on whether it's a local or remote image. |

</details>
  

</details>
