### PR TITLE
chore: update br api params

### DIFF
--- a/source/infrastructure/cli/magic-config.ts
+++ b/source/infrastructure/cli/magic-config.ts
@@ -340,7 +340,7 @@ async function processCreateOptions(options: any): Promise<void> {
     {
       type: "input",
       name: "crossAccountBedrockKey",
-      message: "If you don't need to use cross-account Bedrock functionality, you can press Enter to skip this step. When invoking Bedrock across accounts, you need to provide an API key, which should be stored in the Secrets Manager of your current account. Please enter the ARN of the API key, for example: arn:aws:secretsmanager:us-west-2:<aws_account_id>:secret:SampleAPIKey-AqZDIw",
+      message: "If you don't need to use cross-account Bedrock or connect OpenAI API, you can press Enter to skip this step. When invoking Bedrock across accounts or OpenAI API, you need to provide an API key, which should be stored in the Secrets Manager of your current account. Please enter the ARN of the API key, for example: arn:aws:secretsmanager:us-west-2:<aws_account_id>:secret:SampleAPIKey",
       initial: options.crossAccountBedrockKey,
       validate(crossAccountBedrockKey: string) {
         if ( crossAccountBedrockKey.includes('arn:aws:secretsmanager') || crossAccountBedrockKey.trim() === '') {

--- a/source/lambda/online/common_logic/common_utils/pydantic_models.py
+++ b/source/lambda/online/common_logic/common_utils/pydantic_models.py
@@ -1,9 +1,6 @@
-import collections.abc
 import copy
-import os
-from typing import Any, Union
+from typing import Any, Union, Dict
 
-import boto3
 from common_logic.common_utils.chatbot_utils import ChatbotManager
 from common_logic.common_utils.constant import (
     ChatbotMode,
@@ -17,6 +14,7 @@ from common_logic.common_utils.constant import (
 from common_logic.common_utils.logger_utils import get_logger
 from common_logic.common_utils.python_utils import update_nest_dict
 from pydantic import BaseModel, ConfigDict, Field
+from sm_utils import get_secret_value
 
 
 logger = get_logger("pydantic_models")
@@ -37,7 +35,17 @@ class LLMConfig(AllowBaseModel):
     provider: ModelProvider = ModelProvider.BEDROCK
     model_id: LLMModelType = LLMModelType.CLAUDE_3_SONNET
     base_url: Union[str,None] = None
+    br_api_key_arn: Union[str,None] = None
+    openai_api_key_arn: Union[str,None] = None
+    br_api_key: Union[str,None] = None
+    openai_api_key: Union[str,None] = None
     model_kwargs: dict = {"temperature": 0.01, "max_tokens": 4096}
+
+    def model_post_init(self, __context: Any) -> None:
+        if self.br_api_key_arn is not None and self.base_url is not None:
+            self.br_api_key = get_secret_value(self.br_api_key_arn)
+        if self.openai_api_key_arn is not None and self.base_url is not None:
+            self.openai_api_key = get_secret_value(self.openai_api_key_arn)
 
 
 class QueryRewriteConfig(LLMConfig):

--- a/source/portal/src/locale/en.json
+++ b/source/portal/src/locale/en.json
@@ -82,7 +82,7 @@
     "topKRetrievals": "Top K Retrievals",
     "score": "Relevance Score",
     "scenarioDesc": "Applicable scenario for the current session",
-    "modelTypeDesc": "LLM model type",
+    "modelTypeDesc": "LLM model provider",
     "modelNameDesc": "LLM used in the current session",
     "maxTokenDesc": " Max length of tokens that LLM process in a sequence",
     "maxRoundsDesc": "Max rounds of dialog that saved in memory",
@@ -97,7 +97,7 @@
     "embeddingModel": "Embedding Model Name",
     "noChatbotFound": "No chatbot found",
     "scenario": "Scenario",
-    "modelType": "Model type",
+    "modelType": "Model provider",
     "maxTokens": "Max Tokens",
     "temperature": "Temperature",
     "sessionHistory": "Recent chats",
@@ -292,8 +292,10 @@
       "submitIssue": "Submit an Issue"
     },
     "apiEndpoint": "API Endpoint",
-    "apiEndpointDesc": "Enter the Bedrock API endpoint URL",
+    "apiEndpointDesc": "Enter the API endpoint URL",
     "apiModelName": "API Model Name",
-    "apiModelNameDesc": "Enter the model name for the API"
+    "apiModelNameDesc": "Enter the model name for the API",
+    "apiKeyArn": "API Key ARN",
+    "apiKeyArnDesc": "Enter the ARN of the secret in AWS Secrets Manager that stores the API key for Bedrock/OpenAI"
   }
 }

--- a/source/portal/src/locale/zh.json
+++ b/source/portal/src/locale/zh.json
@@ -91,7 +91,7 @@
     "topKRetrievals": "召回最关联的K条",
     "score": "相关度分数",
     "scenarioDesc": "当前会话的应用场景",
-    "modelTypeDesc": "LLM 模型类型",
+    "modelTypeDesc": "LLM 模型供应商",
     "modelNameDesc": "当前会话使用的大语言模型",
     "maxTokenDesc": "序列中处理的最大token长度",
     "maxRoundsDesc": "保存在上下文中的记忆最大轮数",
@@ -107,7 +107,7 @@
     "embeddingModelName": "向量化模型",
     "embeddingModelDesc": "用于此机器人的向量化操作",
     "scenario": "场景",
-    "modelType": "模型类型",
+    "modelType": "模型供应商",
     "maxTokens": "最大 Token 数",
     "temperature": "温度",
     "sessionHistory": "历史记录",
@@ -285,8 +285,10 @@
       "submitIssue": "提交问题"
     },
     "apiEndpoint": "API 端点",
-    "apiEndpointDesc": "输入 Bedrock API 端点 URL",
+    "apiEndpointDesc": "输入 API 端点 URL",
     "apiModelName": "API 模型名称",
-    "apiModelNameDesc": "输入 API 使用的模型名称"
+    "apiModelNameDesc": "输入 API 使用的模型名称",
+    "apiKeyArn": "API 密钥 ARN",
+    "apiKeyArnDesc": "输入存储在 AWS Secrets Manager 中用于 Bedrock/OpenAI 的 API 密钥的 ARN"
   }
 }

--- a/source/portal/src/pages/chatbot/ChatBot.tsx
+++ b/source/portal/src/pages/chatbot/ChatBot.tsx
@@ -44,6 +44,8 @@ import {
   BR_API_MODEL_LIST,
   OPENAI_API_MODEL_LIST,
   SHOW_FIGURES,
+  API_ENDPOINT,
+  API_KEY_ARN,
 } from 'src/utils/const';
 import { v4 as uuidv4 } from 'uuid';
 import { MessageDataType, SessionMessage } from 'src/types';
@@ -61,10 +63,6 @@ interface MessageType {
 interface ChatBotProps {
   historySessionId?: string;
 }
-
-// Add these constants near the top with the other constants
-const API_ENDPOINT = 'API_ENDPOINT';
-const API_KEY_ARN = 'API_KEY_ARN';
 
 const ChatBot: React.FC<ChatBotProps> = (props: ChatBotProps) => {
   const { historySessionId } = props;

--- a/source/portal/src/utils/const.ts
+++ b/source/portal/src/utils/const.ts
@@ -140,6 +140,57 @@ export const LLM_BOT_COMMON_MODEL_LIST = [
   },
 ];
 
+export const BR_API_MODEL_LIST = [
+  {
+    label: 'Amazon Nova',
+    options: [
+      { label: 'us.amazon.nova-pro-v1:0', value: 'us.amazon.nova-pro-v1:0' },
+      { label: 'us.amazon.nova-lite-v1:0', value: 'us.amazon.nova-lite-v1:0' },
+      {
+        label: 'us.amazon.nova-micro-v1:0',
+        value: 'us.amazon.nova-micro-v1:0',
+      },
+    ],
+  },
+  {
+    label: 'Claude',
+    options: [
+      {
+        label: 'anthropic.claude-3-sonnet-20240229-v1:0',
+        value: 'anthropic.claude-3-sonnet-20240229-v1:0',
+      },
+      {
+        label: 'us.anthropic.claude-3-opus-20240229-v1:0',
+        value: 'us.anthropic.claude-3-opus-20240229-v1:0',
+      },
+      {
+        label: 'anthropic.claude-3-haiku-20240307-v1:0',
+        value: 'anthropic.claude-3-haiku-20240307-v1:0',
+      },
+      {
+        label: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+        value: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+      },
+      {
+        label: 'anthropic.claude-3-5-haiku-20241022-v1:0',
+        value: 'anthropic.claude-3-5-haiku-20241022-v1:0',
+      },
+    ],
+  },
+];
+
+export const OPENAI_API_MODEL_LIST = [
+  {
+    label: 'OpenAI',
+    options: [
+      { label: 'gpt-4o-2024-08-06', value: 'gpt-4o-2024-08-06' },
+      { label: 'gpt-4o-mini-2024-07-18', value: 'gpt-4o-mini-2024-07-18' },
+      { label: 'gpt-4-turbo-2024-04-09', value: 'gpt-4-turbo-2024-04-09' },
+      { label: 'gpt-3.5-turbo-0125', value: 'gpt-3.5-turbo-0125' },
+    ],
+  }, 
+];
+
 export const LLM_BOT_RETAIL_MODEL_LIST = [
   {
     label: 'Qwen',
@@ -183,6 +234,10 @@ export const MODEL_TYPE_LIST: SelectProps.Option[] = [
   {
     label: 'Bedrock API',
     value: 'Bedrock API',
+  },
+  {
+    label: 'OpenAI API',
+    value: 'OpenAI API',
   },
 ];
 
@@ -241,3 +296,6 @@ export const TOPK = 'topK';
 export const SCORE = 'score';
 export const ADITIONAL_SETTINGS = 'additional_settings';
 export const HISTORY_CHATBOT_ID = 'history_chatbot_id';
+export const API_ENDPOINT = 'API_ENDPOINT';
+export const API_KEY_ARN = 'API_KEY_ARN';
+export const SHOW_FIGURES = 'SHOW_FIGURES';


### PR DESCRIPTION
Fixes #


<details>
<summary>🤖 AI-Generated PR Description (Powered by Amazon Bedrock)</summary>

# Description
This pull request includes modifications to various components of the application. The changes involve updating the CLI configuration, workspace stack, and common utility functions. Additionally, localization files for English and Chinese have been updated, along with modifications to the ChatBot component and constant utility file.

## Type of change
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
## File Stats Summary

File number involved in this PR: *7*, unfold to see the details:

<details>

The file changes summary is as follows:

| <div style="width:150px">Files</div> | <div style="width:160px">Changes</div> | <div style="width:320px">Change Summary</div> |
|:-------|:--------|:--------------|
| source/lambda/online/common_logic/common_utils/pydantic_models.py | 12 added, 4 removed | The code changes include removing unused imports, adding typing hints for dictionaries, importing a function to retrieve secret values, and adding attributes and a post-initialization method to the LLMConfig class to handle API keys from AWS Secrets Manager. |
| source/portal/src/locale/en.json | 6 added, 4 removed | The code changes update the descriptions for "modelType" from "LLM model type" to "LLM model provider", add fields for "apiKeyArn" and "apiKeyArnDesc" related to storing API keys in AWS Secrets Manager, and modify the "apiEndpointDesc" description. |
| source/infrastructure/lib/workspace/workspace-stack.ts | 6 added, 27 removed | The code changes involve removing unused imports, removing commented-out code, and removing some function name assignments, while keeping the core functionality intact for handling customer sessions, messages, WebSocket API, and Lambda functions related to the workspace. |
| source/infrastructure/cli/magic-config.ts | 1 added, 1 removed | The code change updates the prompt message for the 'crossAccountBedrockKey' input to include information about providing an API key for connecting to the OpenAI API. |
| source/portal/src/utils/const.ts | 58 added, 0 removed | The code changes introduce new model lists for Anthropic's Claude, Amazon Nova, and OpenAI's GPT models. It also adds OpenAI API as a new model type option and exports related constants for API endpoint, API key ARN, and showing figures. |
| source/portal/src/locale/zh.json | 6 added, 4 removed | 这些代码更改主要涉及更新了一些描述性文本和添加了新的配置选项,包括API端点URL、API模型名称和AWS Secrets Manager中存储的API密钥ARN。 |
| source/portal/src/pages/chatbot/ChatBot.tsx | 60 added, 24 removed | The code changes include adding constants for Bedrock API model list, OpenAI API model list, and a flag to show/hide figures. It also adds input fields for API endpoint and API key ARN when using Bedrock API or OpenAI API, and handles their state and localStorage management. |

</details>
  

</details>



<details>
<summary>🤖 AI-Generated PR Description (Powered by Amazon Bedrock)</summary>

# Description
This pull request includes modifications to various components of the project. The changes primarily focus on enhancing the chatbot functionality, improving the user interface, and updating the translations for different locales.

Specifically, the following modifications have been made:

1. **source/infrastructure/cli/magic-config.ts**: Updated the configuration file for the Magic CLI tool.
2. **source/infrastructure/lib/workspace/workspace-stack.ts**: Modified the workspace stack configuration.
3. **source/lambda/online/common_logic/common_utils/pydantic_models.py**: Updated the Pydantic models used for data validation and serialization.
4. **source/portal/src/locale/en.json** and **source/portal/src/locale/zh.json**: Updated the English and Chinese translations for the user interface.
5. **source/portal/src/pages/chatbot/ChatBot.tsx**: Enhanced the chatbot functionality and improved the user experience.
6. **source/portal/src/utils/const.ts**: Updated constants used throughout the application.

These changes aim to improve the overall user experience, enhance the chatbot's capabilities, and ensure consistency across different locales.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## File Stats Summary

File number involved in this PR: *7*, unfold to see the details:

<details>

The file changes summary is as follows:

| <div style="width:150px">Files</div> | <div style="width:160px">Changes</div> | <div style="width:320px">Change Summary</div> |
|:-------|:--------|:--------------|
| source/portal/src/locale/en.json | 6 added, 4 removed | The code changes update the description for the "modelType" field from "LLM model type" to "LLM model provider", add fields for "apiKeyArn" and "apiKeyArnDesc" related to storing API keys in AWS Secrets Manager, and update the "apiEndpointDesc" field description. |
| source/portal/src/utils/const.ts | 58 added, 0 removed | This code change adds new lists for Amazon Nova, Claude, and OpenAI models, as well as options for OpenAI API and API-related constants like API_ENDPOINT, API_KEY_ARN, and SHOW_FIGURES. |
| source/infrastructure/lib/workspace/workspace-stack.ts | 6 added, 27 removed | The code changes involve removing unused imports, comments, and refactoring some function names in the WorkspaceStack class related to AWS Lambda functions and WebSocket API. |
| source/portal/src/locale/zh.json | 6 added, 4 removed | 这些代码更改调整了一些描述文本和添加了一些新的配置项目,包括:更新了"模型类型"描述为"模型供应商",添加了"API 密钥 ARN"和相关描述用于从 AWS Secrets Manager 获取 API 密钥。 |
| source/infrastructure/cli/magic-config.ts | 1 added, 1 removed | The code change updates the prompt message to include the option for providing an OpenAI API key in addition to the cross-account Bedrock functionality. |
| source/lambda/online/common_logic/common_utils/pydantic_models.py | 12 added, 4 removed | The code changes involve importing necessary modules, defining a LLMConfig class with attributes like provider, model_id, base_url, API keys, and model_kwargs, and adding a post-initialization method to retrieve API keys from AWS Secrets Manager based on provided ARNs. |
| source/portal/src/pages/chatbot/ChatBot.tsx | 59 added, 25 removed | This code change introduces new constants for API model lists, API endpoint, and API key ARN. It also adds state variables and input fields for setting the API endpoint and API key ARN, and updates the model list based on the selected model type (Bedrock, Bedrock API, or OpenAI API). |

</details>
  

</details>
