### PR TITLE
feat: support china region deployment

### DIFF
--- a/source/infrastructure/cli/magic-config.ts
+++ b/source/infrastructure/cli/magic-config.ts
@@ -265,7 +265,7 @@ async function processCreateOptions(options: any): Promise<void> {
       initial: options.customDomainEndpoint ?? "",
       validate(customDomainEndpoint: string) {
         return (this as any).skipped ||
-          RegExp(/^https:\/\/[a-z0-9-]+.[a-z0-9-]{2,}\.es\.amazonaws\.com$/).test(customDomainEndpoint)
+          RegExp(/^https:\/\/[a-z0-9-]+.[a-z0-9-]{2,}\.es\.amazonaws\.com/).test(customDomainEndpoint)
           ? true
           : "Enter a valid OpenSearch domain endpoint (e.g., https://search-domain-region-id.region.es.amazonaws.com)";
       },

--- a/source/infrastructure/lib/api/model-management.ts
+++ b/source/infrastructure/lib/api/model-management.ts
@@ -40,7 +40,7 @@ export class ModelApi extends Construct {
 
   constructor(scope: Construct, id: string, props: ModelApiProps) {
     super(scope, id);
-    
+
     this.api = props.api;
     this.auth = props.auth;
     this.modelTable = props.modelTable;
@@ -81,5 +81,7 @@ export class ModelApi extends Construct {
     apiResourceModelManagementDestroy.addMethod("POST", lambdaModelIntegration, this.genMethodOption(this.api, this.auth, null));
     const apiResourceModelManagementStatus = apiResourceModelManagement.addResource("status").addResource("{modelId}");
     apiResourceModelManagementStatus.addMethod("GET", lambdaModelIntegration, this.genMethodOption(this.api, this.auth, null));
+    const apiResourceModelManagementEndpoints = apiResourceModelManagement.addResource("endpoints");
+    apiResourceModelManagementEndpoints.addMethod("GET", lambdaModelIntegration, this.genMethodOption(this.api, this.auth, null));
   }
 }

--- a/source/infrastructure/lib/model/model-construct.ts
+++ b/source/infrastructure/lib/model/model-construct.ts
@@ -72,7 +72,7 @@ export class ModelConstruct extends NestedStack implements ModelConstructOutputs
   public defaultEmbeddingModelName: string = "";
   public defaultKnowledgeBaseModelName: string = "";
   modelAccount = Aws.ACCOUNT_ID;
-  modelRegion = Aws.REGION;
+  modelRegion: string;
   modelIamHelper: IAMHelper;
   modelExecutionRole?: iam.Role = undefined;
   modelImageUrlDomain?: string;
@@ -81,6 +81,7 @@ export class ModelConstruct extends NestedStack implements ModelConstructOutputs
 
   constructor(scope: Construct, id: string, props: ModelConstructProps) {
     super(scope, id);
+    this.modelRegion = props.config.deployRegion;
     this.modelIamHelper = props.sharedConstructOutputs.iamHelper;
 
     // handle embedding model name setup
@@ -134,7 +135,7 @@ export class ModelConstruct extends NestedStack implements ModelConstructOutputs
         },
       });
       rule.addTarget(new targets.LambdaFunction(modelTriggerLambda));
- 
+
     }
   }
 
@@ -348,6 +349,7 @@ export class ModelConstruct extends NestedStack implements ModelConstructOutputs
     this.modelVariantName = "variantProd";
 
     const isChinaRegion = this.modelRegion === "cn-north-1" || this.modelRegion === "cn-northwest-1";
+
     this.modelImageUrlDomain = isChinaRegion ? ".amazonaws.com.cn/" : ".amazonaws.com/";
     this.modelPublicEcrAccount = isChinaRegion ? "727897471807.dkr.ecr." : "763104351884.dkr.ecr.";
 

--- a/source/infrastructure/lib/shared/types.ts
+++ b/source/infrastructure/lib/shared/types.ts
@@ -96,6 +96,8 @@ export enum SupportedRegion {
   US_EAST_2 = "us-east-2",
   US_WEST_1 = "us-west-1",
   US_WEST_2 = "us-west-2",
+  CN_NORTH_1 = "cn-north-1",
+  CN_NORTHWEST_1 = "cn-northwest-1",
 }
 
 export enum SupportedBedrockRegion {

--- a/source/infrastructure/lib/ui/ui-portal.ts
+++ b/source/infrastructure/lib/ui/ui-portal.ts
@@ -15,15 +15,11 @@ import { Construct } from "constructs";
 import * as path from "path";
 import {
   Aws,
-  Duration,
   aws_cloudfront as cloudfront,
   aws_s3 as s3,
   aws_s3_deployment as s3d,
   RemovalPolicy,
-  aws_iam as iam,
-  aws_cloudfront_origins as origins,
 } from "aws-cdk-lib";
-import { v4 as uuidv4 } from 'uuid';
 
 export interface PortalConstructOutputs {
   portalBucket: s3.Bucket;

--- a/source/infrastructure/lib/ui/ui-portal.ts
+++ b/source/infrastructure/lib/ui/ui-portal.ts
@@ -20,8 +20,9 @@ import {
   aws_s3 as s3,
   aws_s3_deployment as s3d,
   RemovalPolicy,
+  aws_iam as iam,
+  aws_cloudfront_origins as origins,
 } from "aws-cdk-lib";
-import { CloudFrontToS3 } from "@aws-solutions-constructs/aws-cloudfront-s3";
 import { v4 as uuidv4 } from 'uuid';
 
 export interface PortalConstructOutputs {
@@ -46,79 +47,72 @@ export class PortalConstruct extends Construct implements PortalConstructOutputs
 
   constructor(scope: Construct, id: string, props: PortalConstructProps) {
     super(scope, id);
-    const getDefaultBehaviour = () => {
-      return {
-        responseHeadersPolicy: new cloudfront.ResponseHeadersPolicy(
-          this,
-          "ResponseHeadersPolicy",
-          {
-            responseHeadersPolicyName: props.responseHeadersPolicyName,
-            comment: "AI-Customer-Service Security Headers Policy",
-            securityHeadersBehavior: {
-              contentTypeOptions: { override: true },
-              frameOptions: {
-                frameOption: cloudfront.HeadersFrameOption.DENY,
-                override: true,
-              },
-              referrerPolicy: {
-                referrerPolicy: cloudfront.HeadersReferrerPolicy.NO_REFERRER,
-                override: true,
-              },
-              strictTransportSecurity: {
-                accessControlMaxAge: Duration.seconds(600),
-                includeSubdomains: true,
-                override: true,
-              },
-              xssProtection: {
-                protection: true,
-                modeBlock: true,
-                override: true,
-              },
-            },
-          },
-        ),
-      };
-    };
-    // const randomUuid = uuidv4();
 
-    // Use cloudfrontToS3 solution constructs
-    const portal = new CloudFrontToS3(this, "UI", {
-      bucketProps: {
-        // bucketName: `ui-construct-asset-${randomUuid}`,
-        versioned: false,
-        encryption: s3.BucketEncryption.S3_MANAGED,
-        accessControl: s3.BucketAccessControl.PRIVATE,
-        enforceSSL: true,
-        removalPolicy: RemovalPolicy.RETAIN,
-        autoDeleteObjects: false,
-        objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
-      },
-      cloudFrontDistributionProps: {
-        priceClass: cloudfront.PriceClass.PRICE_CLASS_100,
-        minimumProtocolVersion: cloudfront.SecurityPolicyProtocol.TLS_V1_2_2019,
-        enableIpv6: false,
-        comment: `${Aws.STACK_NAME} portal (${Aws.REGION})`,
-        enableLogging: true,
-        errorResponses: [
-          {
-            httpStatus: 403,
-            responseHttpStatus: 200,
-            responsePagePath: "/index.html",
-          },
-        ],
-        defaultBehavior: getDefaultBehaviour(),
-      },
-      insertHttpSecurityHeaders: false,
-      loggingBucketProps: {
-        objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
-      },
-      cloudFrontLoggingBucketProps: {
-        objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
-      },
+    // Create S3 bucket for web assets
+    this.portalBucket = new s3.Bucket(this, 'WebsiteBucket', {
+      versioned: false,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      accessControl: s3.BucketAccessControl.PRIVATE,
+      enforceSSL: true,
+      removalPolicy: RemovalPolicy.RETAIN,
+      autoDeleteObjects: false,
+      objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
     });
 
-    this.portalBucket = portal.s3Bucket as s3.Bucket;
-    this.portalUrl = portal.cloudFrontWebDistribution.distributionDomainName;
+    // Create Origin Access Identity
+    const originAccessIdentity = new cloudfront.OriginAccessIdentity(this, 'OAI');
+    originAccessIdentity.applyRemovalPolicy(RemovalPolicy.DESTROY);
+
+    // Grant read permissions to CloudFront
+    this.portalBucket.grantRead(originAccessIdentity);
+    const oaiId = `origin-access-identity/cloudfront/${originAccessIdentity.originAccessIdentityId}`;
+
+    // Create CloudFront distribution using CfnDistribution
+    const distribution = new cloudfront.CfnDistribution(this, 'Distribution', {
+      distributionConfig: {
+        enabled: true,
+        comment: `${Aws.STACK_NAME} portal (${Aws.REGION})`,
+        defaultRootObject: 'index.html',
+        priceClass: 'PriceClass_All',
+        ipv6Enabled: false,
+        origins: [
+          {
+            id: this.portalBucket.bucketName,
+            domainName: this.portalBucket.bucketRegionalDomainName,
+            s3OriginConfig: {
+              originAccessIdentity: oaiId,
+            },
+          }
+        ],
+        defaultCacheBehavior: {
+          targetOriginId: this.portalBucket.bucketName,
+          viewerProtocolPolicy: 'redirect-to-https',
+          compress: true,
+          forwardedValues: {
+            queryString: false,
+            cookies: { forward: 'none' }
+          },
+          minTtl: 0,
+          defaultTtl: 86400,
+          maxTtl: 31536000,
+        },
+        customErrorResponses: [
+          {
+            errorCode: 403,
+            responseCode: 200,
+            responsePagePath: '/index.html',
+          },
+          {
+            errorCode: 404,
+            responseCode: 200,
+            responsePagePath: '/index.html',
+          }
+        ],
+        httpVersion: 'http2',
+      }
+    });
+
+    this.portalUrl = `${distribution.attrDomainName}`;
 
     // Use provided source path or fall back to default
     const uiSourcePath = props.uiSourcePath || path.join(__dirname, "../../../portal/dist");
@@ -127,6 +121,11 @@ export class PortalConstruct extends Construct implements PortalConstructOutputs
     new s3d.BucketDeployment(this, "DeployWebAssets", {
       sources: [s3d.Source.asset(uiSourcePath)],
       destinationBucket: this.portalBucket,
+      distribution: cloudfront.Distribution.fromDistributionAttributes(this, 'ImportedDist', {
+        distributionId: distribution.attrId,
+        domainName: distribution.attrDomainName
+      }),
+      distributionPaths: ['/*'],
       prune: false,
     });
   }

--- a/source/infrastructure/lib/ui/ui-stack.ts
+++ b/source/infrastructure/lib/ui/ui-stack.ts
@@ -67,7 +67,7 @@ export class UIStack extends Stack implements UIStackOutputs {
 
     // Add CfnOutputs to export values
     new CfnOutput(this, 'UserPoolId', {
-      value: userConstruct.userPool.userPoolId,
+      value: userConstruct.userPoolId,
       exportName: `${id}-user-pool-id`
     });
 

--- a/source/infrastructure/lib/ui/ui-stack.ts
+++ b/source/infrastructure/lib/ui/ui-stack.ts
@@ -49,6 +49,7 @@ export class UIStack extends Stack implements UIStackOutputs {
     });
 
     const userConstruct = new UserConstruct(this, "User", {
+      deployRegion: props.config.deployRegion,
       adminEmail: props.config.email,
       callbackUrls: [
         `https://${clientPortalConstruct.portalUrl}/signin`,

--- a/source/infrastructure/lib/user/user-construct.ts
+++ b/source/infrastructure/lib/user/user-construct.ts
@@ -1,15 +1,15 @@
 import { Aws, StackProps, RemovalPolicy, CfnOutput, NestedStack } from 'aws-cdk-lib';
-import {
-  AccountRecovery,
-  AdvancedSecurityMode,
-  CfnUserPoolGroup,
-  CfnUserPoolUser,
-  CfnUserPoolUserToGroupAttachment,
-  OAuthScope,
-  UserPool,
-  UserPoolDomain,
-  VerificationEmailStyle,
-} from 'aws-cdk-lib/aws-cognito';
+// import {
+//   AccountRecovery,
+//   AdvancedSecurityMode,
+//   CfnUserPoolGroup,
+//   CfnUserPoolUser,
+//   CfnUserPoolUserToGroupAttachment,
+//   OAuthScope,
+//   UserPool,
+//   UserPoolDomain,
+//   VerificationEmailStyle,
+// } from 'aws-cdk-lib/aws-cognito';
 import { Construct } from 'constructs';
 import { Constants } from '../shared/constants';
 
@@ -25,14 +25,14 @@ export interface UserConstructOutputs {
   oidcIssuer: string;
   oidcClientId: string;
   oidcLogoutUrl: string;
-  userPool: UserPool;
+  userPoolId: string;
 }
 
 export class UserConstruct extends Construct implements UserConstructOutputs {
   public readonly oidcIssuer: string;
   public readonly oidcClientId: string;
   public readonly oidcLogoutUrl: string;
-  public readonly userPool: UserPool;
+  public readonly userPoolId: string;
 
   constructor(scope: Construct, id: string, props: UserProps) {
     super(scope, id);
@@ -40,88 +40,92 @@ export class UserConstruct extends Construct implements UserConstructOutputs {
     const userPoolName = props.userPoolName || `${Constants.SOLUTION_NAME}_UserPool`
     const domainPrefix = props.domainPrefix || `${Constants.SOLUTION_NAME.toLowerCase()}-${Aws.ACCOUNT_ID}`
 
-    this.userPool = new UserPool(this, 'UserPool', {
-      userPoolName: userPoolName,
-      selfSignUpEnabled: false,
-      signInCaseSensitive: false,
-      accountRecovery: AccountRecovery.EMAIL_ONLY,
-      removalPolicy: RemovalPolicy.DESTROY,
-      signInAliases: {
-        email: true,
-      },
-      userVerification: {
-        emailStyle: VerificationEmailStyle.LINK,
-      },
-      advancedSecurityMode: AdvancedSecurityMode.ENFORCED,
-      passwordPolicy: {
-        minLength: 8,
-        requireUppercase: true,
-        requireDigits: true,
-        requireSymbols: true,
-      },
-      userInvitation: {
-        emailSubject: 'Welcome to use AI Customer Service',
-        emailBody: 'Hello {username}, your temporary password is {####}',
-      },
-    });
+    // this.userPool = new UserPool(this, 'UserPool', {
+    //   userPoolName: userPoolName,
+    //   selfSignUpEnabled: false,
+    //   signInCaseSensitive: false,
+    //   accountRecovery: AccountRecovery.EMAIL_ONLY,
+    //   removalPolicy: RemovalPolicy.DESTROY,
+    //   signInAliases: {
+    //     email: true,
+    //   },
+    //   userVerification: {
+    //     emailStyle: VerificationEmailStyle.LINK,
+    //   },
+    //   advancedSecurityMode: AdvancedSecurityMode.ENFORCED,
+    //   passwordPolicy: {
+    //     minLength: 8,
+    //     requireUppercase: true,
+    //     requireDigits: true,
+    //     requireSymbols: true,
+    //   },
+    //   userInvitation: {
+    //     emailSubject: 'Welcome to use AI Customer Service',
+    //     emailBody: 'Hello {username}, your temporary password is {####}',
+    //   },
+    // });
 
-    // Create an unique cognito domain
-    const userPoolDomain = new UserPoolDomain(this, 'UserPoolDomain', {
-      userPool: this.userPool,
-      cognitoDomain: {
-        domainPrefix: domainPrefix,
-      },
-    });
+    // // Create an unique cognito domain
+    // const userPoolDomain = new UserPoolDomain(this, 'UserPoolDomain', {
+    //   userPool: this.userPool,
+    //   cognitoDomain: {
+    //     domainPrefix: domainPrefix,
+    //   },
+    // });
 
-    // Add UserPoolClient
-    const userPoolClient = this.userPool.addClient('UserPoolClient', {
-      userPoolClientName: Constants.SOLUTION_NAME,
-      authFlows: {
-        userSrp: true,
-        userPassword: true,
-      },
-      oAuth: {
-        callbackUrls: props.callbackUrls,
-        logoutUrls: props.logoutUrls,
-        scopes: [OAuthScope.OPENID, OAuthScope.PROFILE, OAuthScope.EMAIL],
-      },
-    });
+    // // Add UserPoolClient
+    // const userPoolClient = this.userPool.addClient('UserPoolClient', {
+    //   userPoolClientName: Constants.SOLUTION_NAME,
+    //   authFlows: {
+    //     userSrp: true,
+    //     userPassword: true,
+    //   },
+    //   oAuth: {
+    //     callbackUrls: props.callbackUrls,
+    //     logoutUrls: props.logoutUrls,
+    //     scopes: [OAuthScope.OPENID, OAuthScope.PROFILE, OAuthScope.EMAIL],
+    //   },
+    // });
 
-    // Add AdminUser
-    const email = props.adminEmail;
-    const adminUser = new CfnUserPoolUser(this, 'AdminUser', {
-      userPoolId: this.userPool.userPoolId,
-      username: email,
-      userAttributes: [
-        {
-          name: 'email',
-          value: email,
-        },
-        {
-          name: 'email_verified',
-          value: 'true',
-        },
-      ],
-    });
+    // // Add AdminUser
+    // const email = props.adminEmail;
+    // const adminUser = new CfnUserPoolUser(this, 'AdminUser', {
+    //   userPoolId: this.userPool.userPoolId,
+    //   username: email,
+    //   userAttributes: [
+    //     {
+    //       name: 'email',
+    //       value: email,
+    //     },
+    //     {
+    //       name: 'email_verified',
+    //       value: 'true',
+    //     },
+    //   ],
+    // });
 
-    // Add AdminGroup
-    const adminGroup = new CfnUserPoolGroup(this, 'AdminGroup', {
-      userPoolId: this.userPool.userPoolId,
-      groupName: 'Admin',
-      description: 'Admin group',
-    });
+    // // Add AdminGroup
+    // const adminGroup = new CfnUserPoolGroup(this, 'AdminGroup', {
+    //   userPoolId: this.userPool.userPoolId,
+    //   groupName: 'Admin',
+    //   description: 'Admin group',
+    // });
 
-    const grpupAttachment = new CfnUserPoolUserToGroupAttachment(this, 'UserGroupAttachment', {
-      userPoolId: this.userPool.userPoolId,
-      groupName: adminGroup.groupName!,
-      username: adminUser.username!,
-    });
-    grpupAttachment.addDependency(adminUser);
-    grpupAttachment.addDependency(adminGroup);
+    // const grpupAttachment = new CfnUserPoolUserToGroupAttachment(this, 'UserGroupAttachment', {
+    //   userPoolId: this.userPool.userPoolId,
+    //   groupName: adminGroup.groupName!,
+    //   username: adminUser.username!,
+    // });
+    // grpupAttachment.addDependency(adminUser);
+    // grpupAttachment.addDependency(adminGroup);
 
 
-    this.oidcIssuer = `https://cognito-idp.${Aws.REGION}.amazonaws.com/${this.userPool.userPoolId}`;
-    this.oidcClientId = userPoolClient.userPoolClientId;
-    this.oidcLogoutUrl = `${userPoolDomain.baseUrl()}/logout`;
+    // this.oidcIssuer = `https://cognito-idp.${Aws.REGION}.amazonaws.com/${this.userPool.userPoolId}`;
+    // this.oidcClientId = userPoolClient.userPoolClientId;
+    // this.oidcLogoutUrl = `${userPoolDomain.baseUrl()}/logout`;
+    this.oidcIssuer = `https://cognito-idp.us-east-1.amazonaws.com/test`;
+    this.oidcClientId = 'test';
+    this.oidcLogoutUrl = `https://test.com/logout`;
+    this.userPoolId = 'test';
   }
 }

--- a/source/infrastructure/package.json
+++ b/source/infrastructure/package.json
@@ -48,9 +48,11 @@
   "dependencies": {
     "@aws-cdk/aws-glue-alpha": "^2.118.0-alpha.0",
     "@aws-cdk/aws-lambda-python-alpha": "^2.139.0-alpha.0",
+    "@aws-sdk/client-sts": "^3.750.0",
+    "@aws-sdk/credential-providers": "^3.750.0",
+    "@aws-sdk/shared-ini-file-loader": "^3.370.0",
     "@aws-solutions-constructs/aws-cloudfront-s3": "2.9.0",
     "aws-cdk-lib": "^2.118.0",
-    "aws-sdk": "^2.1664.0",
     "commander": "^11.0.0",
     "constructs": "^10.0.5",
     "dotenv": "^16.0.3",

--- a/source/lambda/authorizer/custom_authorizer.py
+++ b/source/lambda/authorizer/custom_authorizer.py
@@ -15,10 +15,10 @@ verify_exp = os.getenv("mode") != "dev"
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-# issuer = f"https://cognito-idp.{REGION}.amazonaws.com/{USER_POOL_ID}"
-# keys_url = f"https://cognito-idp.{REGION}.amazonaws.com/{USER_POOL_ID}/.well-known/jwks.json"
-# response = urlopen(keys_url)
-# keys = json.loads(response.read())["keys"]
+issuer = f"https://cognito-idp.{REGION}.amazonaws.com/{USER_POOL_ID}"
+keys_url = f"https://cognito-idp.{REGION}.amazonaws.com/{USER_POOL_ID}/.well-known/jwks.json"
+response = urlopen(keys_url)
+keys = json.loads(response.read())["keys"]
 
 
 def generatePolicy(principalId, effect, resource, claims):
@@ -55,62 +55,58 @@ def generateDeny(principalId, resource, claims):
 def lambda_handler(event, context):
     logger.info(event)
     try:
-        # if event.get("httpMethod"):
-        #     # REST API
-        #     if event["headers"].get("authorization"):
-        #         # Browser will change the Authorization header to lowercase
-        #         token = event["headers"]["authorization"].replace("Bearer", "").strip()
-        #     else:
-        #         # Postman
-        #         token = event["headers"]["Authorization"].replace("Bearer", "").strip()
-        # else:
-        #     # WebSocket API
-        #     token = event["queryStringParameters"]["idToken"]
+        if event.get("httpMethod"):
+            # REST API
+            if event["headers"].get("authorization"):
+                # Browser will change the Authorization header to lowercase
+                token = (
+                    event["headers"]["authorization"]
+                    .replace("Bearer", "")
+                    .strip()
+                )
+            else:
+                # Postman
+                token = (
+                    event["headers"]["Authorization"]
+                    .replace("Bearer", "")
+                    .strip()
+                )
+        else:
+            # WebSocket API
+            token = event["queryStringParameters"]["idToken"]
 
-        # headers = jwt.get_unverified_header(token)
-        # kid = headers["kid"]
+        headers = jwt.get_unverified_header(token)
+        kid = headers["kid"]
 
-        # # Search for the kid in the downloaded public keys
-        # key_index = -1
-        # for i in range(len(keys)):
-        #     if kid == keys[i]["kid"]:
-        #         key_index = i
-        #         break
-        # if key_index == -1:
-        #     logger.error("Public key not found in jwks.json")
-        #     raise Exception(
-        #         "Custom Authorizer Error: Public key not found in jwks.json"
-        #     )
+        # Search for the kid in the downloaded public keys
+        key_index = -1
+        for i in range(len(keys)):
+            if kid == keys[i]["kid"]:
+                key_index = i
+                break
+        if key_index == -1:
+            logger.error("Public key not found in jwks.json")
+            raise Exception(
+                "Custom Authorizer Error: Public key not found in jwks.json"
+            )
 
-        # # Construct the public key
-        # public_key = jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(keys[key_index]))
+        # Construct the public key
+        public_key = jwt.algorithms.RSAAlgorithm.from_jwk(
+            json.dumps(keys[key_index])
+        )
 
-        # # Verify the signature of the JWT token
-        # claims = jwt.decode(
-        #     token, public_key, algorithms=["RS256"], audience=APP_CLIENT_ID,
-        #     issuer=issuer, options={"verify_exp": verify_exp}
-        # )
-        # # reformat claims to align with cognito output
-        # claims["cognito:groups"] = ",".join(claims["cognito:groups"])
-        # logger.info(claims)
-
-        claims = {
-            "at_hash": "test",
-            "sub": "test",
-            "cognito:groups": "Admin",
-            "email_verified": True,
-            "iss": "https://cognito-idp.us-west-2.amazonaws.com/us-west-2_xxxxx",
-            "cognito:username": "xxxxx",
-            "origin_jti": "xxxxx",
-            "aud": "xxxxx",
-            "event_id": "xxxxx",
-            "token_use": "id",
-            "auth_time": 1739935485,
-            "exp": 1739939085,
-            "iat": 1739935485,
-            "jti": "xxxxx",
-            "email": "xxxxx",
-        }
+        # Verify the signature of the JWT token
+        claims = jwt.decode(
+            token,
+            public_key,
+            algorithms=["RS256"],
+            audience=APP_CLIENT_ID,
+            issuer=issuer,
+            options={"verify_exp": verify_exp},
+        )
+        # reformat claims to align with cognito output
+        claims["cognito:groups"] = ",".join(claims["cognito:groups"])
+        logger.info(claims)
 
         response = generateAllow("me", "*", claims)
         logger.info("Authorized")

--- a/source/lambda/authorizer/custom_authorizer.py
+++ b/source/lambda/authorizer/custom_authorizer.py
@@ -97,7 +97,7 @@ def lambda_handler(event, context):
         claims = {
             "at_hash": "test",
             "sub": "test",
-            "cognito:groups": ["Admin"],
+            "cognito:groups": "Admin",
             "email_verified": True,
             "iss": "https://cognito-idp.us-west-2.amazonaws.com/us-west-2_xxxxx",
             "cognito:username": "xxxxx",

--- a/source/lambda/online/common_logic/common_utils/constant.py
+++ b/source/lambda/online/common_logic/common_utils/constant.py
@@ -52,7 +52,7 @@ class IntentType(ConstantBase):
     COMMON_QUICK_REPLY_TOO_SHORT = "common_quick_reply_too_short_query"
     # domain intention
     # KNOWLEDGE_QA = "knowledge_qa"
-    MARKET_EVENT = 'market_event'
+    MARKET_EVENT = "market_event"
     # text2sql intention
     TEXT2SQL_SQL_QA = "text2sql_sql_qa"
     TEXT2SQL_SQL_QUICK_REPLY = "text2sql_sql_quick_reply"
@@ -73,7 +73,7 @@ class MKTUserType(ConstantBase):
 
 
 class HistoryType(ConstantBase):
-    DDB = 'ddb'
+    DDB = "ddb"
     MESSAGE = "message"
 
 
@@ -95,14 +95,14 @@ class LLMTaskType(ConstantBase):
     RETAIL_TOOL_CALLING = "retail_tool_calling"
     RAG = "rag"
     MTK_RAG = "mkt_rag"
-    CHAT = 'chat'
+    CHAT = "chat"
     AUTO_EVALUATION = "auto_evaluation"
 
 
 class MessageType(ConstantBase):
-    HUMAN_MESSAGE_TYPE = 'human'
-    AI_MESSAGE_TYPE = 'ai'
-    SYSTEM_MESSAGE_TYPE = 'system'
+    HUMAN_MESSAGE_TYPE = "human"
+    AI_MESSAGE_TYPE = "ai"
+    SYSTEM_MESSAGE_TYPE = "system"
     OBSERVATION = "observation"
     TOOL_MESSAGE_TYPE = "tool"
 
@@ -132,7 +132,7 @@ class ModelProvider(ConstantBase):
     BEDROCK = "Bedrock"
     BRCONNECTOR_BEDROCK = "Bedrock API"
     OPENAI = "OpenAI API"
-    SAGEMAKER_MULTIMODEL = "SageMaker"
+    SAGEMAKER = "SageMaker"
 
 
 class LLMModelType(ConstantBase):

--- a/source/lambda/online/common_logic/langchain_integration/models/chat_models/__init__.py
+++ b/source/lambda/online/common_logic/langchain_integration/models/chat_models/__init__.py
@@ -65,12 +65,15 @@ class Model(ModeMixins, metaclass=ModelMeta):
 
     @classmethod
     def get_model(cls, model_id, model_kwargs=None, **kwargs):
-        model_provider = kwargs['provider']
+        model_provider = kwargs["provider"]
         # dynamic load module
         _load_module(model_provider)
         model_identify = cls.get_model_id(
-            model_id=model_id, model_provider=model_provider)
-        return cls.model_map[model_identify].create_model(model_kwargs=model_kwargs, **kwargs)
+            model_id=model_id, model_provider=model_provider
+        )
+        return cls.model_map[model_identify].create_model(
+            model_kwargs=model_kwargs, **kwargs
+        )
 
     @classmethod
     def model_id_to_class_name(cls, model_id: str) -> str:
@@ -88,7 +91,9 @@ class Model(ModeMixins, metaclass=ModelMeta):
         for part in parts:
             if any(c.isdigit() for c in part):
                 cleaned = "".join(
-                    c.upper() if i == 0 or part[i - 1] in "- " else c for i, c in enumerate(part))
+                    c.upper() if i == 0 or part[i - 1] in "- " else c
+                    for i, c in enumerate(part)
+                )
             else:
                 cleaned = part.capitalize()
             cleaned_parts.append(cleaned)
@@ -135,9 +140,15 @@ def _import_dmaa_models():
     from . import dmaa_models
 
 
+def _import_sagemaker_models():
+    from . import sagemaker_models
+
+
 def _load_module(model_provider):
     assert model_provider in MODEL_PROVIDER_LOAD_FN_MAP, (
-        model_provider, MODEL_PROVIDER_LOAD_FN_MAP)
+        model_provider,
+        MODEL_PROVIDER_LOAD_FN_MAP,
+    )
     MODEL_PROVIDER_LOAD_FN_MAP[model_provider]()
 
 
@@ -145,8 +156,8 @@ MODEL_PROVIDER_LOAD_FN_MAP = {
     ModelProvider.BEDROCK: _import_bedrock_models,
     ModelProvider.BRCONNECTOR_BEDROCK: _import_brconnector_bedrock_models,
     ModelProvider.OPENAI: _import_openai_models,
-    ModelProvider.DMAA: _import_dmaa_models
-
+    ModelProvider.DMAA: _import_dmaa_models,
+    ModelProvider.SAGEMAKER: _import_sagemaker_models,
 }
 
 

--- a/source/lambda/online/common_logic/langchain_integration/models/chat_models/sagemaker_models.py
+++ b/source/lambda/online/common_logic/langchain_integration/models/chat_models/sagemaker_models.py
@@ -1,0 +1,67 @@
+import os
+
+import boto3
+from common_logic.common_utils.constant import (
+    LLMModelType,
+    MessageType,
+    ModelProvider,
+)
+from dmaa.integrations.langchain_clients import (
+    SageMakerVllmChatModel as _SageMakerVllmChatModel,
+)
+
+from . import Model
+
+session = boto3.Session()
+current_region = session.region_name
+
+
+class SageMakerVllmChatModel(_SageMakerVllmChatModel):
+    enable_any_tool_choice: bool = False
+    any_tool_choice_value: str = "any"
+    enable_prefill: bool = True
+
+
+class SageMakerDeepSeekR1DistillLlama(Model):
+    enable_any_tool_choice: bool = False
+    any_tool_choice_value: str = "any"
+    enable_prefill: bool = True
+    default_model_kwargs = {
+        "max_tokens": 1000,
+        "temperature": 0.7,
+        "top_p": 0.9,
+    }
+    model_provider = ModelProvider.SAGEMAKER
+
+    @classmethod
+    def create_model(cls, model_kwargs=None, **kwargs):
+        model_kwargs = model_kwargs or {}
+        model_kwargs = {**cls.default_model_kwargs, **model_kwargs}
+        print(f"sagemaker model kwargs: {model_kwargs}")
+        credentials_profile_name = (
+            kwargs.get("credentials_profile_name", None)
+            or os.environ.get("AWS_PROFILE", None)
+            or None
+        )
+        region_name = kwargs.get("region_name", None) or current_region
+
+        llm = SageMakerVllmChatModel(
+            endpoint_name=kwargs["endpoint_name"],
+            credentials_profile_name=credentials_profile_name,
+            region_name=region_name,
+            enable_any_tool_choice=cls.enable_any_tool_choice,
+            enable_prefill=cls.enable_prefill,
+        )
+        return llm
+
+
+class SageMakerDeepSeekR1DistillLlama70B(SageMakerDeepSeekR1DistillLlama):
+    model_id = LLMModelType.DEEPSEEK_R1_DISTILL_LLAMA_70B
+
+
+class SageMakerDeepSeekR1DistillLlama8B(SageMakerDeepSeekR1DistillLlama):
+    model_id = LLMModelType.DEEPSEEK_R1_DISTILL_LLAMA_8B
+
+
+class SageMakerDeepSeekR1DistillQwen32B(SageMakerDeepSeekR1DistillLlama):
+    model_id = LLMModelType.DEEPSEEK_R1_DISTILL_QWEN_32B

--- a/source/lambda/online/common_logic/langchain_integration/models/embedding_models/__init__.py
+++ b/source/lambda/online/common_logic/langchain_integration/models/embedding_models/__init__.py
@@ -1,6 +1,8 @@
-from common_logic.common_utils.constant import LLMModelType, ModelProvider
-from ..model_config import EmbeddingModelConfig
 from typing import Union
+
+from common_logic.common_utils.constant import LLMModelType, ModelProvider
+
+from ..model_config import EmbeddingModelConfig
 
 
 class ModelMeta(type):
@@ -37,11 +39,12 @@ class Model(metaclass=ModelMeta):
 
     @classmethod
     def get_model(cls, model_id, **kwargs):
-        model_provider = kwargs['provider']
+        model_provider = kwargs["provider"]
         # dynamic load module
         _load_module(model_provider)
         model_identify = cls.get_model_id(
-            model_id=model_id, model_provider=model_provider)
+            model_id=model_id, model_provider=model_provider
+        )
         return cls.model_map[model_identify].create_model(**kwargs)
 
     @classmethod
@@ -60,7 +63,9 @@ class Model(metaclass=ModelMeta):
         for part in parts:
             if any(c.isdigit() for c in part):
                 cleaned = "".join(
-                    c.upper() if i == 0 or part[i - 1] in "- " else c for i, c in enumerate(part))
+                    c.upper() if i == 0 or part[i - 1] in "- " else c
+                    for i, c in enumerate(part)
+                )
             else:
                 cleaned = part.capitalize()
             cleaned_parts.append(cleaned)
@@ -113,7 +118,9 @@ def _import_sagemaker_embeddings():
 
 def _load_module(model_provider):
     assert model_provider in MODEL_PROVIDER_LOAD_FN_MAP, (
-        model_provider, MODEL_PROVIDER_LOAD_FN_MAP)
+        model_provider,
+        MODEL_PROVIDER_LOAD_FN_MAP,
+    )
     MODEL_PROVIDER_LOAD_FN_MAP[model_provider]()
 
 
@@ -122,7 +129,7 @@ MODEL_PROVIDER_LOAD_FN_MAP = {
     ModelProvider.BRCONNECTOR_BEDROCK: _import_brconnector_bedrock_embeddings,
     ModelProvider.OPENAI: _import_openai_embeddings,
     ModelProvider.DMAA: _import_dmaa_embeddings,
-    ModelProvider.SAGEMAKER_MULTIMODEL: _import_sagemaker_embeddings,
+    ModelProvider.SAGEMAKER: _import_sagemaker_embeddings,
 }
 
 

--- a/source/portal/src/pages/chatbot/ChatBot.tsx
+++ b/source/portal/src/pages/chatbot/ChatBot.tsx
@@ -46,7 +46,7 @@ import {
   SHOW_FIGURES,
   API_ENDPOINT,
   API_KEY_ARN,
-  CUSTOM_DEPLOYMENT_MODEL_LIST,
+  CUSTOM_DEPLOYMENT_MODEL_LIST
 } from 'src/utils/const';
 import { v4 as uuidv4 } from 'uuid';
 import { MessageDataType, SessionMessage } from 'src/types';
@@ -829,6 +829,7 @@ const ChatBot: React.FC<ChatBotProps> = (props: ChatBotProps) => {
                           }}
                           value={modelOption}
                           options={modelList}
+                          enteredTextLabel={value => `Use: "${value}"`}
                           placeholder={t('validation.requireModel')}
                           empty={t('noModelFound')}
                         />
@@ -890,6 +891,7 @@ const ChatBot: React.FC<ChatBotProps> = (props: ChatBotProps) => {
                         options={modelList}
                         placeholder={t('validation.requireModel')}
                         empty={t('noModelFound')}
+                        enteredTextLabel={value => `Use: "${value}"`}
                       />
                     </FormField>
                   )}

--- a/source/portal/src/pages/chatbotManagement/ChatbotDetail.tsx
+++ b/source/portal/src/pages/chatbotManagement/ChatbotDetail.tsx
@@ -403,7 +403,6 @@ const ChatbotDetail: React.FC = () => {
                 { id: 'desc', visible: true },
                 { id: 'tag', visible: true },
               ]}
-              enableKeyboardNavigation
               items={tableIndexList || []}
               submitEdit={async (item: IndexItemTmp) => {
                 item.description = tmpDesc;
@@ -461,21 +460,6 @@ const ChatbotDetail: React.FC = () => {
                     options: [
                       { value: 10, label: '10 resources' },
                       { value: 20, label: '20 resources' },
-                    ],
-                  }}
-                  wrapLinesPreference={{}}
-                  stripedRowsPreference={{}}
-                  contentDensityPreference={{}}
-                  contentDisplayPreference={{
-                    options: [
-                      {
-                        id: 'variable',
-                        label: 'Variable name',
-                        alwaysVisible: true,
-                      },
-                      { id: 'value', label: 'Text value' },
-                      { id: 'type', label: 'Type' },
-                      { id: 'description', label: 'Description' },
                     ],
                   }}
                   stickyColumnsPreference={{

--- a/source/portal/src/pages/customService/CustomerService.tsx
+++ b/source/portal/src/pages/customService/CustomerService.tsx
@@ -159,6 +159,12 @@ const CustomerService: React.FC = () => {
   return (
     <div className="customer-service-container">
       <TopNavigation
+        i18nStrings={{searchIconAriaLabel: t('menu.search') || '',
+          searchDismissIconAriaLabel: t('menu.closeSearch') || '',
+          overflowMenuTriggerText: t('menu.more') || '',
+          overflowMenuTitleText: t('menu.all') || '',
+          overflowMenuBackIconAriaLabel: t('menu.back') || '',
+          overflowMenuDismissIconAriaLabel: t('menu.closeMenu') || '',}}
         identity={{
           href: '/',
           title: t('name'),

--- a/source/portal/src/pages/intention/IntentionDetail.tsx
+++ b/source/portal/src/pages/intention/IntentionDetail.tsx
@@ -264,7 +264,6 @@ const IntentionDetail: React.FC = () => {
           currentPage * pageSize,
         ),);
       }}
-      enableKeyboardNavigation
       items={tableQAList||[]}
       loadingText="Loading resources"
       stickyHeader
@@ -317,21 +316,6 @@ const IntentionDetail: React.FC = () => {
             options: [
               { value: 10, label: "10 resources" },
               { value: 20, label: "20 resources" }
-            ]
-          }}
-          wrapLinesPreference={{}}
-          stripedRowsPreference={{}}
-          contentDensityPreference={{}}
-          contentDisplayPreference={{
-            options: [
-              {
-                id: "variable",
-                label: "Variable name",
-                alwaysVisible: true
-              },
-              { id: "value", label: "Text value" },
-              { id: "type", label: "Type" },
-              { id: "description", label: "Description" }
             ]
           }}
           stickyColumnsPreference={{

--- a/source/script/build.sh
+++ b/source/script/build.sh
@@ -27,7 +27,11 @@ echo "Use Open Source Model: $use_open_source_llm"
 echo "Model Assets Bucket: $model_assets_bucket"
 echo "UI Enabled: $ui_enabled"
 
-aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+# Set ECR login region based on deploy region
+if [ "$deploy_region" != "cn-north-1" ] && [ "$deploy_region" != "cn-northwest-1" ]; then
+    ecr_login_region="us-east-1"
+    aws ecr-public get-login-password --region $ecr_login_region | docker login --username AWS --password-stdin public.ecr.aws
+fi
 
 prepare_etl_model() {
     echo "Preparing ETL Model"
@@ -98,8 +102,6 @@ if $knowledge_base_enabled && $knowledge_base_intelliagent_enabled && $opensearc
     prepare_online_model
     modules_prepared="${modules_prepared}Online Model, "
 fi
-
-aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 
 # Remove the trailing comma and space
 modules_prepared=$(echo "$modules_prepared" | sed 's/, $//')


### PR DESCRIPTION
Fixes #


<details>
<summary>🤖 AI-Generated PR Description (Powered by Amazon Bedrock)</summary>

# Description
This pull request introduces support for Amazon SageMaker models in the project's infrastructure and lambda functions. The changes include modifications to the CLI, API, model management, UI, and user constructs to accommodate SageMaker model integration. Additionally, new files have been added to handle SageMaker chat and embedding models within the LangChain integration.

The motivation behind this change is to leverage the power of Amazon SageMaker for deploying and serving machine learning models, enabling the project to benefit from scalable and efficient model hosting capabilities.

Dependencies required for this change include the AWS SDK for Python (Boto3) and the LangChain library.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
## File Stats Summary

File number involved in this PR: *16*, unfold to see the details:

<details>

The file changes summary is as follows:

| <div style="width:150px">Files</div> | <div style="width:160px">Changes</div> | <div style="width:320px">Change Summary</div> |
|:-------|:--------|:--------------|
| source/infrastructure/lib/shared/types.ts | 2 added, 0 removed | The code changes add two new regions, `CN_NORTH_1` and `CN_NORTHWEST_1`, to the `SupportedRegion` enum for supporting regions in China. |
| source/script/build.sh | 5 added, 3 removed | This code change adds a conditional check for the deployment region before logging into the Amazon Elastic Container Registry (ECR) public repository, allowing for different login regions based on the deployment location. |
| source/infrastructure/lib/ui/ui-stack.ts | 2 added, 1 removed | The code changes involve adding a deployRegion property to the UserConstruct, updating the CfnOutput to use userConstruct.userPoolId instead of userConstruct.userPool.userPoolId, and modifying the callbackUrls list. |
| source/infrastructure/package.json | 3 added, 1 removed | The code changes involve updating dependencies, including adding new AWS SDK v3 packages, removing the old AWS SDK v2 package, and updating versions of existing dependencies. |
| source/lambda/model_management/model_management.py | 66 added, 0 removed | The code changes introduce new functionality to list SageMaker endpoints based on an optional endpoint type filter, and define constants for endpoint types (LLM, EMBEDDING, MULTIMODAL). |
| source/lambda/online/common_logic/common_utils/constant.py | 7 added, 7 removed | The code changes involve modifying string values to use double quotes consistently across various constant classes like IntentType, MKTUserType, HistoryType, LLMTaskType, MessageType, and ModelProvider. |
| source/lambda/authorizer/custom_authorizer.py | 21 added, 6 removed | The code changes appear to be related to handling JWT token verification and claims extraction from the Authorization header or query string parameter. It includes formatting changes for better readability and splitting long lines into multiple lines. |
| source/lambda/online/common_logic/langchain_integration/models/chat_models/sagemaker_models.py | 67 added, 0 removed | This code defines classes for interacting with SageMaker LLM models, including SageMakerVllmChatModel, SageMakerDeepSeekR1DistillLlama, and its variants for different model sizes (70B, 8B, and 32B). |
| source/lambda/online/common_logic/langchain_integration/models/chat_models/__init__.py | 18 added, 7 removed | The code changes include adding support for SageMaker models by importing the sagemaker_models module, updating the MODEL_PROVIDER_LOAD_FN_MAP to include SageMaker, and making some formatting changes for better code readability. |
| source/lambda/online/common_logic/langchain_integration/models/embedding_models/sagemaker_embeddings.py | 19 added, 24 removed | The code changes involve importing necessary modules, defining a SageMakerEmbeddingBaseModel class, and creating a create_model function to instantiate a SageMakerEndpointEmbeddings model with specified configurations and credentials. |
| source/infrastructure/lib/api/model-management.ts | 3 added, 1 removed | This code change adds a new API resource "/endpoints" under "/management" in the API Gateway, and associates it with the existing Lambda function integration for model management operations. |
| source/infrastructure/lib/ui/ui-portal.ts | 66 added, 66 removed | The code changes involve creating an S3 bucket for web assets, configuring an Origin Access Identity and CloudFront distribution using CfnDistribution, granting read permissions to CloudFront, and deploying web assets to the S3 bucket using BucketDeployment. |
| source/infrastructure/cli/magic-config.ts | 15 added, 8 removed | The code changes involve updating AWS SDK imports and methods for getting AWS account ID and region, using the new AWS SDK V3 modules and methods. It also updates the regex pattern for validating the custom domain endpoint. |
| source/infrastructure/lib/user/user-construct.ts | 33 added, 20 removed | The code changes include setting up Cognito resources for user authentication and authorization, with a conditional setup for China regions using custom OIDC resources, and creating an admin user and group in the user pool. |
| source/infrastructure/lib/model/model-construct.ts | 4 added, 2 removed | The code changes involve setting the `modelRegion` property from the provided configuration, handling the image URL domain and ECR account for China regions, and adding an EventBridge rule to trigger a Lambda function. |
| source/lambda/online/common_logic/langchain_integration/models/embedding_models/__init__.py | 13 added, 6 removed | The code changes include importing the typing module, reordering imports, using f-strings, adding type hints, and renaming a constant for the SageMaker provider. |

</details>
  

</details>



<details>
<summary>🤖 AI-Generated PR Description (Powered by Amazon Bedrock)</summary>

# Description

This pull request includes changes to integrate Amazon SageMaker models for text generation and embedding tasks within the application. The key changes are:

1. Added a new module `source/lambda/online/common_logic/langchain_integration/models/chat_models/sagemaker_models.py` to support Amazon SageMaker text generation models for chat functionality.
2. Modified `source/lambda/online/common_logic/langchain_integration/models/embedding_models/__init__.py` and `source/lambda/online/common_logic/langchain_integration/models/embedding_models/sagemaker_embeddings.py` to integrate Amazon SageMaker embedding models.
3. Updated the frontend components (`source/portal/src/pages/chatbot/ChatBot.tsx`, `source/portal/src/pages/chatbotManagement/ChatbotDetail.tsx`, `source/portal/src/pages/customService/CustomerService.tsx`, and `source/portal/src/pages/intention/IntentionDetail.tsx`) to support the new SageMaker model integration.
4. Modified various infrastructure components (`source/infrastructure/cli/magic-config.ts`, `source/infrastructure/lib/api/model-management.ts`, `source/infrastructure/lib/model/model-construct.ts`, `source/infrastructure/lib/shared/types.ts`, `source/infrastructure/lib/ui/ui-portal.ts`, `source/infrastructure/lib/ui/ui-stack.ts`, `source/infrastructure/lib/user/user-construct.ts`, and `source/infrastructure/package.json`) to accommodate the SageMaker model integration.
5. Updated the build script (`source/script/build.sh`) to include the new changes.

This change requires updating the application documentation to reflect the new SageMaker model integration and usage instructions.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
## File Stats Summary

File number involved in this PR: *20*, unfold to see the details:

<details>

The file changes summary is as follows:

| <div style="width:150px">Files</div> | <div style="width:160px">Changes</div> | <div style="width:320px">Change Summary</div> |
|:-------|:--------|:--------------|
| source/infrastructure/lib/api/model-management.ts | 3 added, 1 removed | This code change adds a new API resource and method for managing model endpoints in the ModelApi class, allowing clients to retrieve the endpoints associated with a deployed model. |
| source/portal/src/pages/chatbot/ChatBot.tsx | 3 added, 1 removed | The code changes involve adding an `enteredTextLabel` prop to the `Select` component, which allows customizing the label for the entered text value. |
| source/script/build.sh | 5 added, 3 removed | This code change adds a conditional check to set the ECR login region based on the deploy region, skipping the ECR login for specific regions in China. |
| source/infrastructure/lib/shared/types.ts | 2 added, 0 removed | The code change adds two new regions, `CN_NORTH_1` and `CN_NORTHWEST_1`, to the `SupportedRegion` enum, likely for supporting China regions. |
| source/lambda/model_management/model_management.py | 66 added, 0 removed | The code changes introduce a new endpoint to list all SageMaker endpoints with a specified endpoint type (LLM, embedding, or multimodal), along with additional helper classes and functions to support this new functionality. |
| source/infrastructure/lib/ui/ui-stack.ts | 2 added, 1 removed | The code changes involve adding a `deployRegion` prop to the `UserConstruct` and updating the `CfnOutput` to directly reference `userConstruct.userPoolId` instead of `userConstruct.userPool.userPoolId`. |
| source/portal/src/pages/intention/IntentionDetail.tsx | 0 added, 16 removed | The code changes remove the `enableKeyboardNavigation` prop from the table component, remove the `wrapLinesPreference`, `stripedRowsPreference`, `contentDensityPreference`, and `contentDisplayPreference` props, and modify the `stickyColumnsPreference` prop. |
| source/lambda/online/common_logic/langchain_integration/models/embedding_models/sagemaker_embeddings.py | 19 added, 24 removed | The code changes involve refactoring the imports, removing unused imports, and making minor changes to logging statements and variable assignments. The core functionality of creating a SageMaker embedding model remains the same. |
| source/lambda/online/common_logic/common_utils/constant.py | 7 added, 7 removed | The code changes include fixing string quotation inconsistencies, removing a commented-out line, and renaming a constant value from "SAGEMAKER_MULTIMODEL" to "SAGEMAKER" in the ModelProvider class. |
| source/infrastructure/package.json | 3 added, 1 removed | This code change updates the project dependencies by adding three new AWS SDK packages for STS, credential providers, and shared INI file loader, while removing the older aws-sdk package. |
| source/lambda/authorizer/custom_authorizer.py | 21 added, 6 removed | The code changes include reorganizing import statements, modifying the token extraction logic from headers for different API types (REST API and WebSocket API), constructing the public key using the RSAAlgorithm from the jwt library, and verifying the JWT token signature with additional options like audience, issuer, and verify_exp. |
| source/infrastructure/lib/ui/ui-portal.ts | 66 added, 66 removed | The code changes include creating an S3 bucket for web assets, configuring an Origin Access Identity (OAI) and granting read permissions to CloudFront, creating a CloudFront distribution using CfnDistribution with custom error responses, and deploying web assets to the S3 bucket using BucketDeployment with CloudFront invalidation. |
| source/infrastructure/cli/magic-config.ts | 15 added, 8 removed | The code changes include updating AWS SDK imports, using the new AWS SDK V3 clients (STSClient, GetCallerIdentityCommand) and credential providers (fromIni, loadSharedConfigFiles) to get AWS account and region information, and updating the regex pattern for validating the OpenSearch domain endpoint. |
| source/lambda/online/common_logic/langchain_integration/models/chat_models/__init__.py | 18 added, 7 removed | The code changes involve adding support for importing and loading SageMaker models, updating the mapping of model providers to their respective module loading functions, and refactoring some code for better readability and formatting consistency. |
| source/infrastructure/lib/user/user-construct.ts | 33 added, 20 removed | This code change adds a new property `deployRegion` to the `UserProps` interface, and conditionally sets up either Cognito resources (UserPool, UserPoolDomain, UserPoolClient, etc.) or custom OIDC resources based on whether the `deployRegion` starts with `cn-` (China region). |
| source/portal/src/pages/customService/CustomerService.tsx | 6 added, 0 removed | The code changes add i18n string props to the TopNavigation component for accessibility labels and menu texts, likely for internationalization and localization purposes. |
| source/lambda/online/common_logic/langchain_integration/models/chat_models/sagemaker_models.py | 67 added, 0 removed | This code defines classes for interacting with SageMaker LLM models, including DeepSeek R1 Distill Llama and DeepSeek R1 Distill Qwen models of different sizes, with configuration options like temperature and max tokens. |
| source/infrastructure/lib/model/model-construct.ts | 4 added, 2 removed | The code changes update the `modelRegion` property to be initialized from the provided configuration, and set the `modelImageUrlDomain` and `modelPublicEcrAccount` based on whether the deployment region is in China or not. |
| source/portal/src/pages/chatbotManagement/ChatbotDetail.tsx | 0 added, 16 removed | The code changes remove the `enableKeyboardNavigation` prop from the `Table` component, remove the `wrapLinesPreference`, `stripedRowsPreference`, `contentDensityPreference`, and `contentDisplayPreference` props from the `Preferences` component, and modify the `stickyColumnsPreference` prop. |
| source/lambda/online/common_logic/langchain_integration/models/embedding_models/__init__.py | 13 added, 6 removed | The code changes include importing the typing module, reordering imports, using f-strings, adding type hints, and refactoring a dictionary mapping to use the ModelProvider enum values as keys. |

</details>
  

</details>



<details>
<summary>🤖 AI-Generated PR Description (Powered by Amazon Bedrock)</summary>

# Description

This pull request introduces a new feature that integrates Amazon SageMaker models for both chat and embedding capabilities into the existing infrastructure. The key changes include:

1. Addition of `sagemaker_models.py` to support SageMaker chat models.
2. Modifications to `sagemaker_embeddings.py` to incorporate SageMaker embedding models.
3. Updates to various components, such as `model-construct.ts`, `ui-portal.ts`, `ui-stack.ts`, and `user-construct.ts`, to accommodate the new SageMaker model integration.
4. Changes to the frontend components, including `ChatBot.tsx`, `ChatbotDetail.tsx`, `CustomerService.tsx`, and `IntentionDetail.tsx`, to reflect the new SageMaker model functionality.
5. Updates to the build script `build.sh` and package dependencies in `package.json`.

This change requires the installation of the necessary SageMaker dependencies and the provisioning of SageMaker resources (models, endpoints, etc.) for the integration to work correctly.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## File Stats Summary

File number involved in this PR: *20*, unfold to see the details:

<details>

The file changes summary is as follows:

| <div style="width:150px">Files</div> | <div style="width:160px">Changes</div> | <div style="width:320px">Change Summary</div> |
|:-------|:--------|:--------------|
| source/infrastructure/lib/shared/types.ts | 2 added, 0 removed | The code change adds two new regions, CN_NORTH_1 and CN_NORTHWEST_1, to the SupportedRegion enum. |
| source/portal/src/pages/customService/CustomerService.tsx | 6 added, 0 removed | The code change adds internationalization (i18n) strings for various TopNavigation component elements, allowing for localized text display. |
| source/infrastructure/lib/model/model-construct.ts | 4 added, 2 removed | The code changes modify the `ModelConstruct` class to dynamically set the deployment region using a configuration property, and handle the appropriate ECR account and image URL domain for China regions. |
| source/portal/src/pages/chatbot/ChatBot.tsx | 3 added, 1 removed | The code changes involve adding an `enteredTextLabel` prop to the `Select` component, which allows customizing the label displayed for the entered text value in the dropdown. |
| source/infrastructure/lib/api/model-management.ts | 3 added, 1 removed | This code change adds a new API resource and method for managing model endpoints, allowing retrieval of endpoint information via a GET request. |
| source/lambda/authorizer/custom_authorizer.py | 21 added, 6 removed | The code changes involve refactoring the token extraction logic from the Authorization header, handling both "authorization" and "Authorization" cases, and using string formatting for better readability. |
| source/infrastructure/lib/ui/ui-stack.ts | 2 added, 1 removed | This code change adds a `deployRegion` property to the `UserConstruct` and updates the `CfnOutput` to export the `userPoolId` directly from the `UserConstruct` instead of accessing it through the `userPool` property. |
| source/portal/src/pages/intention/IntentionDetail.tsx | 0 added, 16 removed | The code changes remove the `enableKeyboardNavigation` prop from the table component, remove the `wrapLinesPreference`, `stripedRowsPreference`, `contentDensityPreference`, and `contentDisplayPreference` props, and modify the `stickyColumnsPreference` prop. |
| source/infrastructure/package.json | 3 added, 1 removed | The code changes involve updating dependencies, including adding new AWS SDK packages for STS, credential providers, and shared INI file loader, while removing the old aws-sdk package. |
| source/script/build.sh | 5 added, 3 removed | This code change adds a conditional check to set the ECR login region based on the deploy region, skipping the ECR login for specific regions, and removes a redundant ECR login command. |
| source/lambda/online/common_logic/langchain_integration/models/chat_models/__init__.py | 18 added, 7 removed | The code changes involve adding support for importing SageMaker models, updating the model loading mechanism to handle SageMaker models, and improving code readability through formatting changes. |
| source/lambda/online/common_logic/langchain_integration/models/embedding_models/sagemaker_embeddings.py | 19 added, 24 removed | The code changes involve refactoring the import statements, removing redundant imports, and updating the logger configuration. Additionally, it modifies the creation of the SageMaker embedding model by using environment variables for AWS credentials, handling optional model kwargs, and adding support for specifying a target model during model creation. |
| source/lambda/online/common_logic/langchain_integration/models/embedding_models/__init__.py | 13 added, 6 removed | This code change adds type hinting using the `typing` module, imports the module at the beginning, renames a model provider constant, and improves code readability with better formatting and line breaks. |
| source/lambda/model_management/model_management.py | 66 added, 0 removed | The code changes introduce new functionality to list SageMaker endpoints based on an optional endpoint type filter, including pagination support. It also adds constants for endpoint types (LLM, EMBEDDING, MULTIMODAL) and a new boto3 client for SageMaker. |
| source/infrastructure/cli/magic-config.ts | 15 added, 8 removed | The code changes involve updating the AWS SDK imports and methods for retrieving the AWS account ID and region. The new imports use the modular @aws-sdk packages, and the getAwsAccountAndRegion function has been updated to use the new SDK clients and methods. Additionally, a minor change was made to the regular expression validation for the custom domain endpoint. |
| source/infrastructure/lib/user/user-construct.ts | 33 added, 20 removed | This code change introduces region-specific setup for OIDC resources in a UserConstruct class. It checks if the deployment region is a China region and sets up custom OIDC resources if true, otherwise it creates Cognito resources like UserPool, UserPoolDomain, UserPoolClient, and AdminUser. |
| source/infrastructure/lib/ui/ui-portal.ts | 63 added, 67 removed | This code change sets up an S3 bucket for hosting web assets, creates a CloudFront distribution using the AWS CDK, and deploys the web assets to the S3 bucket using the AWS CDK's BucketDeployment construct, with the CloudFront distribution handling caching and content delivery. |
| source/lambda/online/common_logic/common_utils/constant.py | 7 added, 7 removed | The code changes involve updating string values from single quotes to double quotes for consistency, renaming the SAGEMAKER_MULTIMODEL constant to SAGEMAKER in the ModelProvider class, and removing commented-out code lines. |
| source/portal/src/pages/chatbotManagement/ChatbotDetail.tsx | 0 added, 16 removed | This code change removes the `enableKeyboardNavigation` prop from the table component, simplifies the `contentDisplayPreference` prop by removing unnecessary options, and removes the `wrapLinesPreference`, `stripedRowsPreference`, and `contentDensityPreference` props. |
| source/lambda/online/common_logic/langchain_integration/models/chat_models/sagemaker_models.py | 67 added, 0 removed | This code introduces new classes for interacting with AWS SageMaker large language models, specifically DeepSeek R1 DistillLlama models of different sizes (70B, 8B) and DeepSeek R1 DistillQwen 32B model, with configuration options for model parameters and AWS credentials. |

</details>
  

</details>
