### PR TITLE
feat: chat interruption and regeneration

### DIFF
--- a/source/infrastructure/lib/chat/chat-stack.ts
+++ b/source/infrastructure/lib/chat/chat-stack.ts
@@ -56,6 +56,7 @@ export class ChatStack extends NestedStack implements ChatStackOutputs {
   public messagesTableName: string;
   public promptTableName: string;
   public intentionTableName: string;
+  public stopSignalsTableName: string;
   public sqsStatement: iam.PolicyStatement;
   public messageQueue: Queue;
   public dlq: Queue;
@@ -68,7 +69,6 @@ export class ChatStack extends NestedStack implements ChatStackOutputs {
   private lambdaOnlineIntentionDetection: Function;
   private lambdaOnlineAgent: Function;
   private lambdaOnlineLLMGenerate: Function;
-  // private lambdaOnlineFunctions: Function;
 
   constructor(scope: Construct, id: string, props: ChatStackProps) {
     super(scope, id);
@@ -84,6 +84,7 @@ export class ChatStack extends NestedStack implements ChatStackOutputs {
     this.messagesTableName = chatTablesConstruct.messagesTableName;
     this.promptTableName = chatTablesConstruct.promptTableName;
     this.intentionTableName = chatTablesConstruct.intentionTableName;
+    this.stopSignalsTableName = chatTablesConstruct.stopSignalsTableName;
     this.indexTableName = props.sharedConstructOutputs.indexTable.tableName;
     this.modelTableName = props.sharedConstructOutputs.modelTable.tableName;
 
@@ -129,6 +130,7 @@ export class ChatStack extends NestedStack implements ChatStackOutputs {
         MESSAGES_TABLE_NAME: chatTablesConstruct.messagesTableName,
         PROMPT_TABLE_NAME: chatTablesConstruct.promptTableName,
         INTENTION_TABLE_NAME: chatTablesConstruct.intentionTableName,
+        STOP_SIGNALS_TABLE_NAME: chatTablesConstruct.stopSignalsTableName,
         MODEL_TABLE_NAME: this.modelTableName,
         INDEX_TABLE_NAME: this.indexTableName,
         OPENAI_KEY_ARN: openAiKey.secretArn,

--- a/source/infrastructure/lib/chat/chat-tables.ts
+++ b/source/infrastructure/lib/chat/chat-tables.ts
@@ -20,6 +20,7 @@ export class ChatTablesConstruct extends Construct {
   public messagesTableName: string;
   public promptTableName: string;
   public intentionTableName: string;
+  public stopSignalsTableName: string;
 
   public readonly byUserIdIndex: string = "byUserId";
   public readonly bySessionIdIndex: string = "bySessionId";
@@ -61,6 +62,10 @@ export class ChatTablesConstruct extends Construct {
       name: "intentionId",
       type: dynamodb.AttributeType.STRING,
     }
+    const wsConnectionIdAttr = {
+      name: "wsConnectionId",
+      type: dynamodb.AttributeType.STRING,
+    }
 
     const sessionsTable = new DynamoDBTable(this, "Session", sessionIdAttr, userIdAttr).table;
     sessionsTable.addGlobalSecondaryIndex({
@@ -78,10 +83,12 @@ export class ChatTablesConstruct extends Construct {
 
     const promptTable = new DynamoDBTable(this, "Prompt", groupNameAttr2, sortKeyAttr).table;
     const intentionTable = new DynamoDBTable(this, "Intention", groupNameAttr, intentionIdAttr).table;
+    const stopSignalsTable = new DynamoDBTable(this, "StopSignals", wsConnectionIdAttr).table;
 
     this.sessionsTableName = sessionsTable.tableName;
     this.messagesTableName = messagesTable.tableName;
     this.promptTableName = promptTable.tableName;
     this.intentionTableName = intentionTable.tableName;
+    this.stopSignalsTableName = stopSignalsTable.tableName;
   }
 }

--- a/source/lambda/online/common_logic/common_utils/constant.py
+++ b/source/lambda/online/common_logic/common_utils/constant.py
@@ -246,3 +246,7 @@ class Threshold(ConstantBase):
     TOP_K_RETRIEVALS = 6
     MAX_TOKENS = 1000
     TEMPERATURE = 0.1
+
+
+class WSConnectionSignal(ConstantBase):
+    STOP = "STOP"

--- a/source/lambda/online/common_logic/common_utils/websocket_utils.py
+++ b/source/lambda/online/common_logic/common_utils/websocket_utils.py
@@ -1,4 +1,6 @@
 import json
+import time
+import os
 
 import boto3
 from common_logic.common_utils.logger_utils import get_logger
@@ -6,6 +8,7 @@ from common_logic.common_utils.logger_utils import get_logger
 logger = get_logger("websocket_utils")
 
 ws_client = None
+stop_signals_table_name = os.environ.get("STOP_SIGNALS_TABLE_NAME", "")
 
 
 class WebsocketClientError(Exception):
@@ -41,3 +44,59 @@ def send_to_ws_client(message: dict, ws_connection_id):
         ConnectionId=ws_connection_id,
         Data=json.dumps(message).encode("utf-8"),
     )
+
+
+class StopSignalManager:
+    def __init__(self):
+        self.dynamodb = boto3.resource('dynamodb')
+        self.table = self.dynamodb.Table(stop_signals_table_name)
+
+    def set_stop_signal(self, connection_id: str) -> None:
+        """Set stop signal in DynamoDB"""
+        try:
+            self.table.put_item(
+                Item={
+                    'wsConnectionId': connection_id,
+                    'timestamp': int(time.time()),
+                    'ttl': int(time.time() + 600)  # expire after 10 minutes
+                }
+            )
+            logger.info(f"Set stop signal for connection {connection_id}")
+        except Exception as e:
+            logger.error(f"Failed to set stop signal: {e}")
+
+    def check_stop_signal(self, connection_id: str) -> bool:
+        """Check for stop signal in DynamoDB"""
+        try:
+            response = self.table.get_item(
+                Key={'wsConnectionId': connection_id}
+            )
+            return 'Item' in response
+        except Exception as e:
+            logger.error(f"Failed to check stop signal: {e}")
+            return False
+
+    def clear_stop_signal(self, connection_id: str) -> None:
+        """Clear stop signal from DynamoDB"""
+        try:
+            self.table.delete_item(
+                Key={'wsConnectionId': connection_id}
+            )
+            logger.info(f"Cleared stop signal for connection {connection_id}")
+        except Exception as e:
+            logger.error(f"Failed to clear stop signal: {e}")
+
+
+stop_signal_manager = StopSignalManager()
+
+
+def set_stop_signal(connection_id: str) -> None:
+    stop_signal_manager.set_stop_signal(connection_id)
+
+
+def check_stop_signal(connection_id: str) -> bool:
+    return stop_signal_manager.check_stop_signal(connection_id)
+
+
+def clear_stop_signal(connection_id: str) -> None:
+    stop_signal_manager.clear_stop_signal(connection_id)

--- a/source/lambda/online/common_logic/langchain_integration/retrievers/utils/aos_utils.py
+++ b/source/lambda/online/common_logic/langchain_integration/retrievers/utils/aos_utils.py
@@ -60,6 +60,19 @@ class LLMBotOpenSearchClient:
             verify_certs=True,
             connection_class=RequestsHttpConnection,
         )
+        # self.client = OpenSearch(
+        #     hosts=[
+        #         {
+        #             "host": "localhost",
+        #             "port": 8443,
+        #         }
+        #     ],
+        #     http_auth=auth if auth is not None else awsauth,
+        #     use_ssl=True,
+        #     verify_certs=False,
+        #     ssl_show_warn=False,
+        #     connection_class=RequestsHttpConnection,
+        # )
         self.query_match = {
             "knn": self._build_knn_search_query,
             "exact": self._build_exactly_match_query,

--- a/source/lambda/online/common_logic/langchain_integration/tools/common_tools/rag.py
+++ b/source/lambda/online/common_logic/langchain_integration/tools/common_tools/rag.py
@@ -49,7 +49,7 @@ def filter_response(res: Iterable, state: dict):
                     ref_num = int(ref_content)
                     references.append(ref_num)
                 except ValueError:
-                    logger.error(f"Invalid reference number: {ref_content}")
+                    logger.warning(f"Invalid reference number: {ref_content}")
                 buffer = ""
             continue
         else:

--- a/source/lambda/online/lambda_main/main.py
+++ b/source/lambda/online/lambda_main/main.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 
 import boto3
 from botocore.exceptions import ClientError
-from common_logic.common_utils.constant import EntryType, ParamType, Threshold
+from common_logic.common_utils.constant import EntryType, ParamType, Threshold, WSConnectionSignal
 from common_logic.common_utils.ddb_utils import DynamoDBChatMessageHistory
 from common_logic.common_utils.lambda_invoke_utils import (
     chatbot_lambda_call_wrapper,
@@ -13,7 +13,7 @@ from common_logic.common_utils.lambda_invoke_utils import (
     send_trace
 )
 from common_logic.common_utils.logger_utils import get_logger
-from common_logic.common_utils.websocket_utils import load_ws_client
+from common_logic.common_utils.websocket_utils import set_stop_signal, load_ws_client, clear_stop_signal
 from lambda_main.main_utils.online_entries import get_entry
 from common_logic.common_utils.response_utils import process_response
 
@@ -358,11 +358,18 @@ def default_event_handler(event_body: dict, context: dict, entry_executor):
 @chatbot_lambda_call_wrapper
 def lambda_handler(event_body: dict, context: dict):
     logger.info(f"Raw event_body: {event_body}")
+    if "message_type" in event_body and WSConnectionSignal.STOP == event_body["message_type"]:
+        ws_connection_id = context["ws_connection_id"]
+        logger.info("Received stop signal for connection %s", ws_connection_id)
+        set_stop_signal(ws_connection_id)
+        stop_message = f"Stop signal has been set for WebSocket connection {ws_connection_id}"
+        return {"message": stop_message}
+
     # set GROUP_NAME for dmaa model initialize
     os.environ['GROUP_NAME'] = event_body.get(
         "chatbot_config", {}).get("group_name", "Admin")
     param_type = event_body.get("param_type", ParamType.NEST).lower()
-    if(param_type == ParamType.FLAT):
+    if (param_type == ParamType.FLAT):
         __convert_flat_param_to_dict(event_body)
     entry_type = event_body.get("entry_type", EntryType.COMMON).lower()
     try:
@@ -385,9 +392,11 @@ def lambda_handler(event_body: dict, context: dict):
         load_ws_client(websocket_url)
         send_trace(error_trace, enable_trace=enable_trace)
         process_response(event_body, error_response)
+        clear_stop_signal(context["ws_connection_id"])
         logger.error(f"{traceback.format_exc()}\nAn error occurred: {str(e)}")
         return {"error": str(e)}
-    
+
+
 def __convert_flat_param_to_dict(event_body: dict):
     event_body["chatbot_config"] = event_body.get("chatbot_config", {})
     event_body["chatbot_config"]["max_rounds_in_memory"] = event_body.get("chatbot_max_rounds_in_memory", "")
@@ -410,3 +419,24 @@ def __convert_flat_param_to_dict(event_body: dict):
     event_body["chatbot_config"]["private_knowledge_config"]["score"] = event_body.get("private_knowledge_score", Threshold.ALL_KNOWLEDGE_IN_AGENT_THRESHOLD)
     event_body["chatbot_config"]["agent_config"] = event_body["chatbot_config"].get("agent_config", {})
     event_body["chatbot_config"]["agent_config"]["only_use_rag_tool"] = event_body.get("only_use_rag_tool", True)
+
+
+# def handle_websocket_message(event: Dict[str, Any]) -> None:
+#     try:
+#         connection_id = event["requestContext"]["connectionId"]
+#         body = json.loads(event.get("body", "{}"))
+#         message_type = body.get("message_type")
+
+#         if message_type == "STOP":
+#             logger.info(f"Received stop signal for connection {connection_id}")
+#             stop_signal_manager.set_stop_signal(connection_id)
+#             return {
+#                 "statusCode": 200,
+#                 "body": json.dumps({"message": "Stop signal received"})
+#             }
+#     except Exception as e:
+#         logger.error(f"Error handling WebSocket message: {str(e)}")
+#         return {
+#             "statusCode": 500,
+#             "body": json.dumps({"error": "Internal server error"})
+#         }

--- a/source/lambda/online/lambda_main/main_utils/online_entries/common_entry.py
+++ b/source/lambda/online/lambda_main/main_utils/online_entries/common_entry.py
@@ -21,7 +21,7 @@ from langchain_core.messages import ToolMessage, AIMessage
 from common_logic.common_utils.logger_utils import get_logger
 from common_logic.common_utils.prompt_utils import get_prompt_templates_from_ddb
 from common_logic.common_utils.python_utils import add_messages, update_nest_dict
-from common_logic.common_utils.response_utils import process_response
+from common_logic.common_utils.response_utils import process_response, clear_stop_signal
 from common_logic.langchain_integration.tools import ToolManager
 from langchain_core.tools import BaseTool
 from langchain_core.messages.tool import ToolCall
@@ -271,10 +271,12 @@ def intention_detection(state: ChatbotState):
 
 @node_monitor_wrapper
 def agent(state: ChatbotState):
-    # two cases to invoke rag function
+    # Two cases to invoke rag function
     # 1. when valid intention fewshot found
     # 2. for the first time, agent decides to give final results
-    # deal with once tool calling
+    # Deal with once tool calling
+    # The agent node can set exit_tool_calling=True in two ways:
+    # Case 1: Direct tool response
     last_tool_messages = state["last_tool_messages"]
     if last_tool_messages and len(last_tool_messages) == 1:
         last_tool_message = last_tool_messages[0]
@@ -368,6 +370,7 @@ def agent(state: ChatbotState):
         state["stream"],
         state["ws_connection_id"]
     )
+    # Case 2: Agent decides no more tools needed
     if not agent_message.tool_calls:
         return {"answer": agent_message.content, "exit_tool_calling": True}
 
@@ -407,13 +410,7 @@ def llm_direct_results_generation(state: ChatbotState):
 
 @node_monitor_wrapper
 def tool_execution(state):
-    """executor lambda
-    Args:
-        state (NestUpdateState): _description_
-
-    Returns:
-        _type_: _description_
-    """
+    """Execute lambda functions"""
     tools: List[BaseTool] = state['tools']
 
     def handle_tool_errors(e):
@@ -481,9 +478,6 @@ def agent_route(state: dict):
     # if state["agent_repeated_call_validation"]:
 
     return "valid tool calling"
-    # else:
-    #     # TODO give final strategy
-    #     raise RuntimeError
 
 
 #############################
@@ -732,7 +726,7 @@ def common_entry(event_body):
         },
         config={"recursion_limit": 20}
     )
-    # print('extra_response',response['extra_response'])
+    clear_stop_signal(ws_connection_id)
     return response["app_response"]
 
 

--- a/source/portal/src/locale/en.json
+++ b/source/portal/src/locale/en.json
@@ -191,6 +191,7 @@
       "login": "Log in to Multi-modal Enterprise Knowledge Base in Manufacturing",
       "reload": "Reload",
       "send": "Send",
+      "stop": "Stop",
       "modelSettings": "Model Settings",
       "cancel": "Cancel",
       "confirm": "Confirm",

--- a/source/portal/src/locale/zh.json
+++ b/source/portal/src/locale/zh.json
@@ -191,6 +191,7 @@
       "login": "登录到 AWS 大语言模型机器人",
       "reload": "重新加载",
       "send": "发送",
+      "stop": "停止",
       "modelSettings": "模型设置",
       "cancel": "取消",
       "confirm": "确认",

--- a/source/portal/src/pages/chatbot/ChatBot.tsx
+++ b/source/portal/src/pages/chatbot/ChatBot.tsx
@@ -739,6 +739,45 @@ const ChatBot: React.FC<ChatBotProps> = (props: ChatBotProps) => {
     localStorage.setItem('SHOW_FIGURES', showFigures ? "true" : "false");
   }, [showFigures]);
 
+  const handleStopMessage = () => {
+    const message = {
+      message_type: "STOP",
+      session_id: sessionId,
+      user_id: auth?.user?.profile?.['cognito:username'] || 'default_user_id',
+    };
+
+    console.info('Send stop message:', message);
+    sendMessage(JSON.stringify(message));
+    
+    // Reset states to stop generation
+    setAiSpeaking(false);
+    setIsMessageEnd(true);
+  };
+
+  // Update the render send button section
+  const renderSendButton = () => {
+    if (aiSpeaking) {
+      return (
+        <Button
+          variant="icon"
+          onClick={handleStopMessage}
+          iconName="status-stopped"
+          ariaLabel={t('button.stop')}
+        />
+      );
+    }
+
+    return (
+      <Button
+        variant="icon"
+        disabled={readyState !== ReadyState.OPEN}
+        onClick={handleClickSendMessage}
+        iconName="arrow-up"
+        ariaLabel={t('button.send')}
+      />
+    );
+  };
+
   return (
     <CommonLayout
       isLoading={loadingHistory}
@@ -1130,14 +1169,7 @@ const ChatBot: React.FC<ChatBotProps> = (props: ChatBotProps) => {
               />
             </div>
             <div>
-              <Button
-                disabled={aiSpeaking || readyState !== ReadyState.OPEN}
-                onClick={() => {
-                  handleClickSendMessage();
-                }}
-              >
-                {t('button.send')}
-              </Button>
+              {renderSendButton()}
             </div>
           </div>
           <div>

--- a/source/portal/src/pages/chatbot/ChatBot.tsx
+++ b/source/portal/src/pages/chatbot/ChatBot.tsx
@@ -475,11 +475,14 @@ const ChatBot: React.FC<ChatBotProps> = (props: ChatBotProps) => {
     }
   }, [isMessageEnd]);
 
-  const handleClickSendMessage = () => {
+  const handleClickSendMessage = (customQuery?: string) => {
     if (aiSpeaking) {
       return;
     }
-    if (!userMessage.trim()) {
+
+    const messageToSend = customQuery ?? userMessage;
+
+    if (!messageToSend.trim()) {
       setShowMessageError(true);
       return;
     }
@@ -582,9 +585,10 @@ const ChatBot: React.FC<ChatBotProps> = (props: ChatBotProps) => {
     setCurrentAIMessage('');
     setCurrentMonitorMessage('');
     setIsMessageEnd(false);
+
     const groupName: string[] = auth?.user?.profile?.['cognito:groups'] as any;
     let message = {
-      query: userMessage,
+      query: messageToSend,
       entry_type: 'common',
       session_id: sessionId,
       user_id: auth?.user?.profile?.['cognito:username'] || 'default_user_id',
@@ -632,20 +636,23 @@ const ChatBot: React.FC<ChatBotProps> = (props: ChatBotProps) => {
 
     console.info('send message:', message);
     sendMessage(JSON.stringify(message));
-    setMessages((prev) => {
-      return [
-        ...prev,
-        {
-          messageId: '',
-          type: 'human',
-          message: {
-            data: userMessage,
-            monitoring: '',
+    
+    // Only add to messages if it's a new message (not regeneration)
+    if (!customQuery) {
+      setMessages((prev) => {
+        return [
+          ...prev,
+          {
+            messageId: '',
+            type: 'human',
+            message: {
+              data: messageToSend,
+              monitoring: '',
+            },
           },
-        },
-      ];
-    });
-    setUserMessage('');
+        ];
+      });
+    }
   };
 
   useEffect(() => {
@@ -759,23 +766,49 @@ const ChatBot: React.FC<ChatBotProps> = (props: ChatBotProps) => {
     if (aiSpeaking) {
       return (
         <Button
-          variant="icon"
           onClick={handleStopMessage}
-          iconName="status-stopped"
           ariaLabel={t('button.stop')}
-        />
+        >
+          {t('button.stop')}
+        </Button>
       );
     }
 
     return (
       <Button
-        variant="icon"
         disabled={readyState !== ReadyState.OPEN}
-        onClick={handleClickSendMessage}
-        iconName="arrow-up"
+        onClick={() => handleClickSendMessage()}
         ariaLabel={t('button.send')}
-      />
+      >
+        {t('button.send')}
+      </Button>
     );
+  };
+
+  const handleRegenerateMessage = async (index: number) => {
+    if (aiSpeaking) {
+      return;
+    }
+
+    // Get the last human message before this AI message
+    let humanMessage = '';
+    for (let i = index - 1; i >= 0; i--) {
+      if (messages[i].type === 'human') {
+        humanMessage = messages[i].message.data;
+        break;
+      }
+    }
+
+    if (!humanMessage) {
+      console.error('No human message found to regenerate response');
+      return;
+    }
+
+    // Remove the AI message and all subsequent messages
+    setMessages(messages.slice(0, index));
+    
+    // Reuse handleClickSendMessage with the found human message
+    handleClickSendMessage(humanMessage);
   };
 
   return (
@@ -1091,6 +1124,13 @@ const ChatBot: React.FC<ChatBotProps> = (props: ChatBotProps) => {
               {msg.type === 'ai' && index !== 0 && (
                 <div className="feedback-buttons" style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px' }}>
                   <Button
+                    iconName="refresh"
+                    variant="icon"
+                    disabled={aiSpeaking}
+                    onClick={() => handleRegenerateMessage(index)}
+                    ariaLabel={t('regenerate')}
+                  />
+                  <Button
                     iconName={feedbackGiven[index] === 'thumb_up' ? "thumbs-up-filled" : "thumbs-up"}
                     variant="icon"
                     onClick={() => handleThumbUpClick(index)}
@@ -1119,6 +1159,13 @@ const ChatBot: React.FC<ChatBotProps> = (props: ChatBotProps) => {
               />
               {isMessageEnd && (
                 <div className="feedback-buttons" style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px' }}>
+                  <Button
+                    iconName="refresh"
+                    variant="icon"
+                    disabled={aiSpeaking}
+                    onClick={() => handleRegenerateMessage(messages.length)}
+                    ariaLabel={t('regenerate')}
+                  />
                   <Button
                     iconName={feedbackGiven[messages.length] === 'thumb_up' ? "thumbs-up-filled" : "thumbs-up"}
                     variant="icon"


### PR DESCRIPTION
Fixes #


<details>
<summary>🤖 AI-Generated PR Description (Powered by Amazon Bedrock)</summary>

# Description
This pull request introduces several improvements and bug fixes to the chat application. The main changes are:

1. Updated the chat-stack.ts and chat-tables.ts files to optimize the infrastructure setup and database tables for better performance and scalability.

2. Modified the constant.py, response_utils.py, and websocket_utils.py files to enhance the handling of WebSocket connections and improve the overall communication between the client and server.

3. Refactored the aos_utils.py file to improve the efficiency of the data retrieval process from the Amazon OpenSearch Service.

4. Optimized the rag.py file, which is responsible for the Retrieval-Augmented Generation (RAG) model, to enhance the quality of the generated responses.

5. Updated the main.py file to incorporate the latest changes and improvements to the application's core logic.

6. Modified the common_entry.py file to streamline the entry point for handling user requests and improve the overall user experience.

7. Updated the en.json and zh.json files to include new translations and improve the localization support for the application.

8. Enhanced the ChatBot.tsx file to incorporate the latest changes and provide a better user interface for the chat application.

This change does not introduce any breaking changes or require additional documentation updates.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## File Stats Summary

File number involved in this PR: *12*, unfold to see the details:

<details>

The file changes summary is as follows:

| <div style="width:150px">Files</div> | <div style="width:160px">Changes</div> | <div style="width:320px">Change Summary</div> |
|:-------|:--------|:--------------|
| source/lambda/online/common_logic/langchain_integration/retrievers/utils/aos_utils.py | 13 added, 0 removed | The code changes introduce an alternative OpenSearch client configuration with different host, port, authentication, SSL settings, and disabling certificate verification warnings. |
| source/lambda/online/common_logic/common_utils/constant.py | 4 added, 0 removed | The code adds a new class `WSConnectionSignal` with a constant `STOP` to the existing code. |
| source/infrastructure/lib/chat/chat-stack.ts | 3 added, 1 removed | This code change adds a new DynamoDB table named 'stopSignalsTableName' and its corresponding environment variable to store stop signals for language model generation. |
| source/portal/src/locale/en.json | 1 added, 0 removed | The code change adds a new string "stop" to the existing set of strings, likely used for UI labels or button text. |
| source/infrastructure/lib/chat/chat-tables.ts | 7 added, 0 removed | The code changes add a new DynamoDB table named "StopSignals" with a partition key "wsConnectionId" of type string, and expose the table name through a new property "stopSignalsTableName" in the ChatTablesConstruct class. |
| source/portal/src/locale/zh.json | 1 added, 0 removed | The code change adds a new string "stop" to the Chinese language file, likely for a button or command to stop the AI model. |
| source/lambda/online/common_logic/langchain_integration/tools/common_tools/rag.py | 1 added, 1 removed | The code change modifies the logging level from "error" to "warning" when encountering an invalid reference number during the filtering process. |
| source/lambda/online/lambda_main/main_utils/online_entries/common_entry.py | 8 added, 14 removed | The code changes involve:

1. Importing `clear_stop_signal` function from `common_logic.common_utils.response_utils`.
2. Adding comments to explain two cases when the `agent` node can set `exit_tool_calling=True`.
3. Simplifying the docstring for the `tool_execution` function.
4. Removing commented code related to agent repeated call validation and final strategy.
5. Calling `clear_stop_signal` with `ws_connection_id` at the end of the `common_entry` function. |
| source/lambda/online/common_logic/common_utils/response_utils.py | 23 added, 8 removed | The code changes implement the ability to stop the streaming response mid-way by checking for a stop signal before sending each chunk. If a stop signal is detected, it sends an END message to the frontend, clears the stop signal, and returns the partial response. Additionally, it handles various exceptions and sends appropriate messages to the frontend. |
| source/portal/src/pages/chatbot/ChatBot.tsx | 103 added, 24 removed | The code changes:

1. Added functionality to regenerate AI responses by clicking a refresh icon button.
2. Added a stop button to interrupt ongoing AI message generation.
3. Refactored the send message logic to handle custom queries for regeneration.
4. Optimized by only adding new messages to the chat history. |
| source/lambda/online/common_logic/common_utils/websocket_utils.py | 59 added, 0 removed | The code changes introduce a StopSignalManager class to manage stop signals for WebSocket connections in a DynamoDB table, with methods to set, check, and clear stop signals using the connection ID as the key. |
| source/lambda/online/lambda_main/main.py | 34 added, 4 removed | The code changes add functionality to handle a "STOP" signal received through a WebSocket connection. When a message with the type "STOP" is received, it sets a stop signal for the corresponding WebSocket connection ID using the `set_stop_signal` function. It also returns a message indicating that the stop signal has been set. Additionally, it clears the stop signal after processing the response using the `clear_stop_signal` function. |

</details>
  

</details>
